### PR TITLE
Implement --single-build, & reimplement rollup plugin with generateRoutes

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const program = require('commander')
-const generateRoutes = require('./watcher').generateRoutes
+const { generateRoutes } = require('./watcher')
 
 program
     .option('-d, --debug', 'extra debugging')

--- a/lib/rollup-plugin-filerouter.js
+++ b/lib/rollup-plugin-filerouter.js
@@ -3,8 +3,14 @@ const { name } = require('../package.json')
 const { generateRoutes } = require('./watcher')
 
 module.exports = function svelteFileRouter(inputOptions) {
-  generateRoutes(inputOptions)  
-  return Object.assign(
-    { name },
-  )
+  const firstBuildPromise = generateRoutes({
+    singleBuild: !process.env.ROLLUP_WATCH,
+    ...inputOptions,
+  })
+  return {
+     name,
+     async buildStart() {
+       await firstBuildPromise
+     }
+  }
 }

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -9,40 +9,21 @@ const watchWhiteList = /^_(?:layout|reset|fallback)\./
 // TODO this should be centralized (utils / config)
 const extensions = ['.svelte', '.html']
 
+const defaultOptions = {
+    pages: './src/pages',
+    ignore: [],
+    unknownPropWarnings: true,
+    dynamicImports: false,
+    singleBuild: false,
+    outputFile: path.resolve(__dirname + '/../dist/routes.js').replace(/\\/g, '/'),
+}
+
 
 // TODO logs
 const logPrefix = `[${NAME}]`
 const log = console.log.bind(console, logPrefix)
 log.debug = () => { }
 log.error = console.error.bind(console, logPrefix)
-
-
-module.exports.generateRoutes = async function (inputOptions) {
-    const defaultOptions = {
-        pages: './src/pages',
-        ignore: [],
-        unknownPropWarnings: true,
-        dynamicImports: false,
-        watch: true,
-        outputFile: path.resolve(__dirname + '/../dist/routes.js').replace(/\\/g, '/'),
-    }
-    let options = defaultOptions
-    Object.entries(inputOptions).forEach(([key, value])=>{
-        if(typeof options[key] !== 'undefined'){
-            options[key] = value
-        }
-    })
-    options.pages = path.resolve(options.pages)
-
-    if (await !fsa.exists(options.pages)) {
-        throw new Error(
-            'pages could not be found. Default location: src/pages - create the dir or specify its location in options {pages: path/to/pages}'
-        )
-    }
-
-    return options.watch ? withWatch(options) : withoutWatch(options)
-}
-
 
 
 const renderGeneratedRoutes = async ({
@@ -62,24 +43,12 @@ const resolveOutputFile = async input => {
     return path.resolve(value)
 }
 
-const withoutWatch = options => { renderGeneratedRoutes(options) }
-
-
-const withWatch = options => {
-    const {
-        pages: dir,
-        outputFile,
-    } = options
-
-    log('Watching', dir)
-
-    const watch = new CheapWatch({ dir })
+const generator = options => {
+    const { outputFile } = options
 
     const filenamePromise = resolveOutputFile(outputFile)
 
-    let idlePromise
-
-    const doGenerate = async event => {
+    const generate = async event => {
         if (event) {
           log(`Generate routes (changed: ${event.path})`)
         } else {
@@ -91,6 +60,31 @@ const withWatch = options => {
         await fsa.writeFile(filename, contents, 'utf8')
         log.debug('Written', filename)
     }
+
+    return generate
+}
+
+const singleBuild = async options => {
+  const generate = generator(options)
+
+  await generate().catch(err => {
+      log.error('Failed to generate route files', err)
+  })
+}
+
+const buildWatch = options => {
+    const {
+        pages: dir,
+        outputFile,
+    } = options
+
+    log('Watching', dir)
+
+    const watch = new CheapWatch({ dir })
+
+    let idlePromise
+
+    const doGenerate = generator(options)
 
     const generate = async event => {
         await idlePromise
@@ -125,4 +119,30 @@ const withWatch = options => {
     })
 
     safeGenerate()
+}
+
+async function generateRoutes (inputOptions) {
+    const options = Object.assign({}, defaultOptions, inputOptions)
+
+    options.pages = path.resolve(options.pages)
+
+    if (await !fsa.exists(options.pages)) {
+        throw new Error(
+            'pages could not be found. Default location: src/pages - create the dir or specify its location in options {pages: path/to/pages}'
+        )
+    }
+
+    if (options.singleBuild) {
+      await singleBuild(options)
+    } else {
+      await buildWatch(options)
+    }
+}
+
+// rixo: I'd argue this should remain last because, esthetically, the end is
+// where you (well, I) would expect the result. Also, programmatically, jumping
+// to the end is often easier than trying to locate where the actual code starts,
+// because the top gets crowded with imports, constants, etc.
+module.exports = {
+  generateRoutes,
 }

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -72,7 +72,8 @@ const singleBuild = async options => {
   })
 }
 
-const buildWatch = options => {
+// must resolve when the initial routes have been generated (aka system ready)
+const buildWatch = async options => {
     const {
         pages: dir,
         outputFile,
@@ -89,6 +90,7 @@ const buildWatch = options => {
     const generate = async event => {
         await idlePromise
         idlePromise = doGenerate(event)
+        return idlePromise
     }
 
     const safeGenerate = event =>
@@ -118,7 +120,7 @@ const buildWatch = options => {
         log.error('Failed to watch pages directory', err)
     })
 
-    safeGenerate()
+    await safeGenerate()
 }
 
 async function generateRoutes (inputOptions) {

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -53,7 +53,7 @@ const renderGeneratedRoutes = async ({
     outputFile
 }) => `
     ${await filesToRoutes({ pages, ignore, dynamicImports, outputFile })}
-  
+
     export const options = ${JSON.stringify({ unknownPropWarnings })}
   `
 
@@ -79,7 +79,12 @@ const withWatch = options => {
 
     let idlePromise
 
-    const doGenerate = async () => {
+    const doGenerate = async event => {
+        if (event) {
+          log(`Generate routes (changed: ${event.path})`)
+        } else {
+          log('Generate routes')
+        }
         const filename = await filenamePromise
         await fsa.mkdir(path.dirname(filename), { recursive: true })
         const contents = await renderGeneratedRoutes(options)
@@ -87,24 +92,24 @@ const withWatch = options => {
         log.debug('Written', filename)
     }
 
-    const generate = async () => {
+    const generate = async event => {
         await idlePromise
-        idlePromise = doGenerate()
+        idlePromise = doGenerate(event)
     }
 
-    const safeGenerate = () =>
-        generate().catch(err => {
+    const safeGenerate = event =>
+        generate(event).catch(err => {
             log.error('Failed to generate route files', err)
         })
 
-    const ifIsRoute = fn => x => {
-        const { path: p, stats } = x
+    const ifIsRoute = fn => event => {
+        const { path: p, stats } = event
         if (stats.isDirectory()) return
         if (!extensions.includes(path.extname(p))) return
         const basename = path.basename(p)
         const priv = basename.substr(0, 1) === '_'
         if (priv && !watchWhiteList.test(basename)) return
-        return fn(x)
+        return fn(event)
     }
 
     const maybeRegenerate = ifIsRoute(safeGenerate)
@@ -121,4 +126,3 @@ const withWatch = options => {
 
     safeGenerate()
 }
-


### PR DESCRIPTION
Also, add some logs, so that users can confirm that it works. The watcher, at least. Watchers have a tendency of being unreliable, people like to confirm they work.