### PR TITLE
Adjusted generated file to be a svelte component, now relative to package root by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .history
 node_modules
-dist
+/router.svelte

--- a/lib/template.js
+++ b/lib/template.js
@@ -3,27 +3,44 @@ const path = require('path')
 const fsa = require('./utils/fsa')
 
 const MATCH_BRACKETS = RegExp(/\[[^\[\]]+\]/g);
+const MODULE_PATH = require.resolve('../src/index.js').replace(/\\/g, '/');
 
-module.exports = async function filesToRoutes({ pages, ignore, dynamicImports, outputFile }) {
+module.exports = async function filesToRoutes({
+    unknownPropWarnings,
+    pages,
+    ignore,
+    dynamicImports,
+    outputFile
+}) {
     ignore = Array.isArray(ignore) ? ignore : [ignore]
     const files = await getFiles(pages, ['html', 'svelte'], ignore)
     const routes = convertToRoutes(files)
 
     if (!routes.length) console.log('no routes found in ' + pages)
 
-    return convertToCodeString(routes, pages, dynamicImports, outputFile )
+    return [
+        `<script context="module">`,
+        `import { Router } from '${MODULE_PATH}'`,
+        convertToCodeString(routes, pages, dynamicImports, outputFile ),
+        `export const defaultOptions = ${JSON.stringify({ unknownPropWarnings })}`,
+        `export * from '${MODULE_PATH}'`,
+        `</script>`,
+        `<script>`,
+        `export let routes = defaultRoutes`,
+        `export let options = defaultOptions`,
+        `</script>`,
+        `<Router {...$$props} {routes} {options} />`
+    ].join('\n\n').trim()
 }
-
 
 function convertToCodeString(routes, pages, dynamicImports, outputFile) {
     const imports = dynamicImports ? [] : routes
     const lines = imports.map(
-        route => `import ${route.component} from '${pages.replace(/\\/g, '/')+route.filepath}'`
+        route => `import ${route.component} from '${pages.replace(/\\/g, '/')}${route.filepath}'`
     )
 
-    lines.push(
-        `\n\n export const routes = [`,
-        routes
+    lines.push(`\nexport const defaultRoutes = ${
+        partialStringify(routes
             .filter(r => r.name) //layouts don't have names
             .map(({ filepath, isLayout, component, layouts, ...route }) => ({
                 ...route,
@@ -36,11 +53,10 @@ function convertToCodeString(routes, pages, dynamicImports, outputFile) {
                         ? `() => import('${pages}${routes.filter(r => r.component === n)[0].filepath}').then(m => m.default)`
                         : `() => ${n}`
                 )
-            }))
-            .map(f => partialStringify(f, ['component', 'layouts']))
-            .join(`,\n`),
-        ']'
-    )
+            })),
+            ['component', 'layouts']
+        )
+    }`)
 
     routes.forEach(route => delete route.filepath)
     routes.forEach(route => delete route.isLayout)
@@ -147,17 +163,22 @@ function getParams(string) {
 
 }
 
-function partialStringify(obj, ignoreList) {
-    ignoreList.forEach(key => {
-        let prop = obj[key]
-        if (Array.isArray(prop))
-            prop = prop.map(p => p = `'''${p}'''`)
-        else
-            prop = `'''${prop}'''`
-
-        obj[key] = prop
-    })
-    return JSON.stringify(obj, 0, 2).replace(/"'''|'''"/g, '')
+function partialStringify(obj, ignoreList, escapeOnly = false) {
+    if (Array.isArray(obj)) {
+        obj = obj.map(o => partialStringify(o, ignoreList, true));
+    } else {
+        ignoreList.forEach(key => {
+            let prop = obj[key]
+            if (Array.isArray(prop))
+                prop = prop.map(p => p = `'''${p}'''`)
+            else
+                prop = `'''${prop}'''`
+    
+            obj[key] = prop
+        })
+    }
+    
+    return escapeOnly ? obj : JSON.stringify(obj, 0, 4).replace(/"'''|'''"/g, '')
 }
 
 function alphanumeric(str, replace = '_') {

--- a/lib/template.js
+++ b/lib/template.js
@@ -20,12 +20,11 @@ module.exports = async function filesToRoutes({
 
     return [
         `<script context="module">`,
-        `import { Router } from '${MODULE_PATH}'`,
         convertToCodeString(routes, pages, dynamicImports, outputFile ),
         `export const defaultOptions = ${JSON.stringify({ unknownPropWarnings })}`,
-        `export * from '${MODULE_PATH}'`,
         `</script>`,
         `<script>`,
+        `import { Router } from '${MODULE_PATH}'`,
         `export let routes = defaultRoutes`,
         `export let options = defaultOptions`,
         `</script>`,

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const CheapWatch = require('cheap-watch')
 const fsa = require('./utils/fsa')
-const filesToRoutes = require('./files-to-routes')
+const renderTemplate = require('./template')
 const { name: NAME } = require('../package.json')
 
 // this one should probably use { createFilter } from 'rollup-pluginutils'
@@ -15,7 +15,7 @@ const defaultOptions = {
     unknownPropWarnings: true,
     dynamicImports: false,
     singleBuild: false,
-    outputFile: path.resolve(__dirname + '/../dist/routes.js').replace(/\\/g, '/'),
+    outputFile: path.resolve(__dirname + '/../router.svelte').replace(/\\/g, '/'),
 }
 
 
@@ -25,18 +25,6 @@ const log = console.log.bind(console, logPrefix)
 log.debug = () => { }
 log.error = console.error.bind(console, logPrefix)
 
-
-const renderGeneratedRoutes = async ({
-    unknownPropWarnings,
-    pages,
-    ignore,
-    dynamicImports,
-    outputFile
-}) => `
-    ${await filesToRoutes({ pages, ignore, dynamicImports, outputFile })}
-
-    export const options = ${JSON.stringify({ unknownPropWarnings })}
-  `
 
 const resolveOutputFile = async input => {
     const value = typeof input === 'function' ? await input() : input
@@ -56,7 +44,7 @@ const generator = options => {
         }
         const filename = await filenamePromise
         await fsa.mkdir(path.dirname(filename), { recursive: true })
-        const contents = await renderGeneratedRoutes(options)
+        const contents = await renderTemplate(options)
         await fsa.writeFile(filename, contents, 'utf8')
         log.debug('Written', filename)
     }

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -1,14 +1,14 @@
 <script>
-  import {url} from './utils'
+  import * as utils from './utils'
   import Route from "./Route.svelte";
   import init from "./navigator.js";
-  import { options as _routeOptions, routes as defaultRoutes } from "../dist/routes.js";
   export let routes
+  export let options
 
-  routes = routes || defaultRoutes
+  const url = (path, params) => utils.url(path, params, routes);
 
   let components, route;
   init(routes, update => ({ components, route } = update));
 </script>
 
-<Route {components} {route} {routes} {_routeOptions} {url} rootScope={{}} />
+<Route {components} {route} {routes} _routeOptions={options} {url} rootScope={{}} />

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,3 @@ export { default as Router } from './Router.svelte';
 export { default as Route } from './Route.svelte';
 export * from './store'
 export * from './utils'
-export * from '../dist/routes'

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,7 @@
 import { get } from 'svelte/store'
 import { route } from './store'
-import { routes } from '../dist/routes'
 
-export const url = (path, params) => {
+export const url = (path, params, routes) => {
 
     if (path.match(/^\.\.?\//)) {
         //RELATIVE PATH


### PR DESCRIPTION
With this PR I have moved the location of the generated file to be `<package-root>/router.svelte`. By making this file a component it becomes very simple to consume in your application like so:
```html
<script>
// import Router from 'svelte-routify/router'
import Router from 'svelte-filerouter/router'
</script>
<Router />
```
The actual template for how this component is structured is basically this:
```html
<script context="module">
    // COMPONENT IMPORTS WHEN NON-DYNAMIC HERE

    export const defaultRoutes = []
    export const defaultOptions = {}
</script>
<script>
    import { Router } from '<package-root>/src/index.js'
    export let routes = defaultRoutes
    export let options = defaultOptions
</script>
<Router {...$$props} {routes} {options} />
```