### PR TITLE
README to match https://routify.now.sh/docs/install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 
 ## Install
-``npm i @sveltech/routify@next`` or clone the [starter template](https://github.com/sveltech/routify-starter)
+``npm i -d @sveltech/routify@next`` or clone the [starter template](https://github.com/sveltech/routify-starter)
 
 For the old version (svelte-filerouter), please go [here](https://github.com/sveltech/routify/tree/v1)
 


### PR DESCRIPTION
I presume Routify should be installed as a `devDependency`. Anyhow, at the moment the web site and this README are at odds. Which way is right?