### PR TITLE
streamline Router workflow

### DIFF
--- a/lib/services/compiler.js
+++ b/lib/services/compiler.js
@@ -5,8 +5,8 @@ module.exports = function compiler(files) {
   return files
     .filter(file => !file.isDir)
     .map(cmp => {
-      cmp.path = filepathToUrl(cmp.filepath)
-      cmp.shortPath = cmp.path.replace(/\/(index|_fallback)$/, "");
+      cmp.path = filepathToUrl(cmp.filepath, cmp.ext)
+      cmp.shortPath = cmp.path.replace(/\/(index|_fallback)$/, '')
       cmp.component = makeLegalIdentifier(cmp.path)
       return cmp
     })

--- a/lib/services/scanner.js
+++ b/lib/services/scanner.js
@@ -16,17 +16,13 @@ const defaultMeta = {
 
 const nope = () => false
 
-module.exports = async function scanner({
-  pages,
-  extensions,
-  ignore,
-}) {
+module.exports = async function scanner({ pages, extensions, ignore }) {
   extensions = Array.isArray(extensions) ? extensions : extensions.split(',')
 
   const isIgnored = ignore ? picomatch(ignore) : nope
-  const tree = await getFileTree(pages, isIgnored)
+  const tree = await getFileTree(pages, isIgnored, '', extensions)
   const treeWithDirs = removeUnderscoredDirs(tree)
-  const definedTree = defineFiles(treeWithDirs, extensions)
+  const definedTree = defineFiles(treeWithDirs)
   const sortedTree = sortTree(definedTree)
   const treeWithMeta = await applyMetaToFiles(sortedTree)
   const treeWithAllMeta = applyMetaToTree(treeWithMeta)
@@ -71,8 +67,9 @@ function removeNonSvelteFiles(tree) {
  */
 function applyLayouts(tree, layouts = []) {
   return tree.map(file => {
-    if (file.isDir) file.dir = applyLayouts(file.dir, [...layouts])
-    else {
+    if (file.isDir) {
+      file.dir = applyLayouts(file.dir, [...layouts])
+    } else {
       if (file.isReset || file.meta.reset) layouts = []
       if (file.isLayout) layouts.push(file)
       else file.layouts = layouts
@@ -168,18 +165,36 @@ function sortTree(tree) {
  * defineFiles
  * @param {Object} tree
  */
-function defineFiles(tree, ext) {
+function defineFiles(tree) {
   return tree.map(file => {
-    if (ext.includes(file.ext)) {
-      file.isLayout = frontFiles.includes(file.name)
-      file.isReset = ['_reset'].includes(file.name)
-      file.isIndex = ['index'].includes(file.name)
-      file.isFallback = ['_fallback'].includes(file.name)
-      file.hasParam = file.name.match(/^\[.+\]$/) ? true : false
-    } else file.badExt = true
-    file.dir = file.isDir ? defineFiles(file.dir, ext) : file.dir
+    if (file.isDir) {
+      file.dir = defineFiles(file.dir)
+    } else {
+      if (!file.badExt) {
+        file.isLayout = frontFiles.includes(file.name)
+        file.isReset = ['_reset'].includes(file.name)
+        file.isIndex = ['index'].includes(file.name)
+        file.isFallback = ['_fallback'].includes(file.name)
+        file.hasParam = file.name.match(/^\[.+\]$/) ? true : false
+      }
+    }
     return file
   })
+}
+
+const matchExtension = (extensions, name) => {
+  const matched = extensions.find(ext => {
+    const { length: l } = ext
+    return name.slice(-l) === ext && name.slice(l - 1, l)
+  })
+  if (matched) {
+    const { length: l } = matched
+    const basename = name.slice(0, -l - 1)
+    return [basename, matched, false]
+  } else {
+    const [basename, ext] = name.split('.')
+    return [basename, ext, true]
+  }
 }
 
 /**
@@ -187,13 +202,21 @@ function defineFiles(tree, ext) {
  * @param {String} absoluteDir
  * @param {Boolean} isIgnored
  * @param {String} relativeDir
+ * @param {String} extensions used for mutlipart extensions like .page.svelte
  */
-async function getFileTree(absoluteDir, isIgnored, relativeDir = '') {
+async function getFileTree(
+  absoluteDir,
+  isIgnored,
+  relativeDir = '',
+  extensions
+) {
   const files = await fsa.readdir(absoluteDir)
   const promises = files.map(async filename => {
     const absolutePath = path.resolve(absoluteDir, filename)
     const isDir = await isDirectory(absolutePath, fsa)
-    const [name, ext] = splitString(filename, '.')
+    const [name, ext, badExt] = isDir
+      ? [filename, '', false]
+      : matchExtension(extensions, filename)
     const filepath = `${relativeDir}/${filename}`
 
     const file = {
@@ -201,13 +224,14 @@ async function getFileTree(absoluteDir, isIgnored, relativeDir = '') {
       filepath,
       name,
       ext,
+      badExt,
       isDir,
       relativeDir,
       absolutePath,
     }
 
     file.dir = isAcceptedDir(file, isIgnored)
-      ? await getFileTree(absolutePath, isIgnored, filepath)
+      ? await getFileTree(absolutePath, isIgnored, filepath, extensions)
       : []
     return file
   })

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -12,15 +12,16 @@ module.exports.asyncForEach = async function asyncForEach(array, callback) {
   }
 }
 
-module.exports.splitString = function splitString(str, delimiter) {
-  const pos = str.lastIndexOf(delimiter)
-  if (pos === -1) return [str, null]
-  return [str.substr(0, pos), str.substr(pos + 1)]
-}
+// TODO unused: keep?
+// module.exports.splitString = function splitString(str, delimiter) {
+//   const pos = str.lastIndexOf(delimiter)
+//   if (pos === -1) return [str, null]
+//   return [str.substr(0, pos), str.substr(pos + 1)]
+// }
 
-module.exports.filepathToUrl = path => {
-  path = this.stripExtension(path)
-  return path.replace(/\[([^\]]+)\]/g, ':$1')
+module.exports.filepathToUrl = (path, ext) => {
+  const basepath = path.slice(0, -(ext.length + 1))
+  return basepath.replace(/\[([^\]]+)\]/g, ':$1')
 }
 
 module.exports.stripExtension = str => str.replace(/\.[^\.]+$/, '')
@@ -41,7 +42,8 @@ module.exports.pathToParams = string => {
 
 module.exports.pathToRank = ({ path }) => {
   return path
-    .split('/').filter(Boolean)
+    .split('/')
+    .filter(Boolean)
     .map(str => (str === '_fallback' ? 'A' : str.startsWith(':') ? 'B' : 'C'))
     .join('')
 }

--- a/runtime/Router.svelte
+++ b/runtime/Router.svelte
@@ -5,25 +5,41 @@
   import { routes as routesStore } from './store.js'
   import { suppressWarnings } from './utils.js'
 
+  export let routes
+
+  let layouts
+  let navigator
+
   suppressWarnings()
 
   if (!window.routify) {
     window.routify = {}
   }
 
-  export let routes
-  routesStore.set(routes)
-  let layouts = []
+  const updatePage = (...args) => navigator && navigator.updatePage(...args)
+
+  setContext('routifyupdatepage', updatePage)
 
   const callback = res => (layouts = res)
 
-  $: ({ updatePage, destroy } = init($routesStore, callback))
-  $: updatePage()
-  $: setContext('routifyupdatepage', updatePage)
+  const cleanup = () => {
+    if (!navigator) return
+    navigator.destroy()
+    navigator = null
+  }
 
-  onDestroy(() => {
-    destroy()
-  })
+  const doInit = () => {
+    cleanup()
+    navigator = init(routes, callback)
+    routesStore.set(routes)
+    navigator.updatePage()
+  }
+
+  $: if (routes) doInit()
+
+  onDestroy(cleanup)
 </script>
 
-<Route {layouts} />
+{#if layouts}
+  <Route {layouts} />
+{/if}

--- a/test/unit/build/index.expected.js
+++ b/test/unit/build/index.expected.js
@@ -1,7 +1,7 @@
 
 /**
- * @sveltech/routify 1.0.3
- * File generated Mon Mar 02 2020 03:33:06 GMT+0100 (Central European Standard Time)
+ * @sveltech/routify 1.0.6
+ * File generated Sat Mar 14 2020 00:22:14 GMT+0100 (Central European Standard Time)
  */
 
 //buildRoutes

--- a/test/unit/build/layout.expected.js
+++ b/test/unit/build/layout.expected.js
@@ -1,7 +1,7 @@
 
 /**
- * @sveltech/routify 1.0.3
- * File generated Mon Mar 02 2020 03:33:06 GMT+0100 (Central European Standard Time)
+ * @sveltech/routify 1.0.6
+ * File generated Sat Mar 14 2020 00:22:14 GMT+0100 (Central European Standard Time)
  */
 
 //buildRoutes

--- a/test/unit/build/multi-extensions.expected.js
+++ b/test/unit/build/multi-extensions.expected.js
@@ -9,8 +9,9 @@ import { buildRoutes } from "/home/eric/projects/routify/routify/runtime/buildRo
 
 //dynamic imports
 import __layout from '/pages/_layout.svelte'
-import _foo__layout from '/pages/foo/_layout.svelte'
-import _foo_index from '/pages/foo/index.svelte'
+import _docs_page from '/pages/docs.page.svx'
+import _foo__layout from '/pages/foo/_layout.svx'
+import _foo_docs_page from '/pages/foo/docs.page.svx'
 import _index from '/pages/index.svelte'
 
 //keys
@@ -36,13 +37,25 @@ const layouts = {
 //raw routes
 const _routes = [
   {
-    "component": () => _foo_index,
+    "component": () => _docs_page,
     "meta": {},
-    "isIndex": true,
+    "isIndex": false,
     "isFallback": false,
     "hasParam": false,
-    "path": "/foo/index",
-    "shortPath": "/foo",
+    "path": "/docs.page",
+    "shortPath": "/docs.page",
+    "layouts": [
+      layouts['/_layout']
+    ]
+  },
+  {
+    "component": () => _foo_docs_page,
+    "meta": {},
+    "isIndex": false,
+    "isFallback": false,
+    "hasParam": false,
+    "path": "/foo/docs.page",
+    "shortPath": "/foo/docs.page",
     "layouts": [
       layouts['/_layout'],
       layouts['/foo/_layout']

--- a/test/unit/build/multi-extensions.input.js
+++ b/test/unit/build/multi-extensions.input.js
@@ -1,0 +1,17 @@
+export default {
+  options: {
+    pages: '/pages',
+    extensions: ['svelte', 'svx'],
+  },
+  files: {
+    '/pages/unrelated.md': '# not me',
+    '/pages/index.svelte': 'index',
+    '/pages/_layout.svelte': '<slot/>',
+    '/pages/docs.page.svx': '# hello',
+    '/pages/foo/unrelated.md': '# not me',
+    '/pages/foo/_layout.svx': 'In Foo: <slot/>',
+    '/pages/foo/docs.page.svx': '# foo',
+    // this one should not match
+    '/pages/bar/_layout.page.svelte': 'not me',
+  },
+}

--- a/test/unit/build/multipart-extensions.expected.js
+++ b/test/unit/build/multipart-extensions.expected.js
@@ -9,8 +9,9 @@ import { buildRoutes } from "/home/eric/projects/routify/routify/runtime/buildRo
 
 //dynamic imports
 import __layout from '/pages/_layout.svelte'
-import _foo__layout from '/pages/foo/_layout.svelte'
-import _foo_index from '/pages/foo/index.svelte'
+import _docs from '/pages/docs.page.svx'
+import _foo__layout from '/pages/foo/_layout.page.svx'
+import _foo_docs from '/pages/foo/docs.page.svx'
 import _index from '/pages/index.svelte'
 
 //keys
@@ -36,13 +37,25 @@ const layouts = {
 //raw routes
 const _routes = [
   {
-    "component": () => _foo_index,
+    "component": () => _docs,
     "meta": {},
-    "isIndex": true,
+    "isIndex": false,
     "isFallback": false,
     "hasParam": false,
-    "path": "/foo/index",
-    "shortPath": "/foo",
+    "path": "/docs",
+    "shortPath": "/docs",
+    "layouts": [
+      layouts['/_layout']
+    ]
+  },
+  {
+    "component": () => _foo_docs,
+    "meta": {},
+    "isIndex": false,
+    "isFallback": false,
+    "hasParam": false,
+    "path": "/foo/docs",
+    "shortPath": "/foo/docs",
     "layouts": [
       layouts['/_layout'],
       layouts['/foo/_layout']

--- a/test/unit/build/multipart-extensions.input.js
+++ b/test/unit/build/multipart-extensions.input.js
@@ -1,0 +1,15 @@
+export default {
+  options: {
+    pages: '/pages',
+    extensions: 'svelte,page.svx'
+  },
+  files: {
+    '/pages/unrelated.md': '# not me',
+    '/pages/index.svelte': 'index',
+    '/pages/_layout.svelte': '<slot/>',
+    '/pages/docs.page.svx': '# hello',
+    '/pages/foo/unrelated.md': '# not me',
+    '/pages/foo/_layout.page.svx': 'In Foo: <slot/>',
+    '/pages/foo/docs.page.svx': '# foo',
+  },
+}


### PR DESCRIPTION
## Router

Removes the suit of `$:` that made me uneasy but, more importantly, allows to change the `routes` prop on the fly. Which I think is expected from a prop.

In my code, I made it a store!

~~~html
<Router routes={$routes} />
~~~

## Extensions

Add support for extensions like `.page.svelte` (and some tests).