### PR TITLE
add watchDelay option to Rollup plugin to allow mitigation of races with other Rollup plugins

### DIFF
--- a/lib/services/interface.js
+++ b/lib/services/interface.js
@@ -58,6 +58,10 @@ const start = function start(inputOptions) {
   if (watch) {
     if (options.childProcess) runChildProcess(options.childProcess)
     return {
+      // wait change is intented to mitigate a nasty race between Routify and
+      // rollup-plugin-hot/autocreate plugin (see Rollup plugin source for details)
+      waitChange: async () => watch.waitChange(),
+
       // used by plugins (e.g. Rollup) to block the build until routes are
       // really ready
       waitIdle: async () => Promise.all([buildPromise, watch.waitIdle()]),
@@ -65,11 +69,14 @@ const start = function start(inputOptions) {
       // allows to cleanly closes test runner
       close: () => watch.close(),
     }
-  } else
+  } else {
+    const resolved = Promise.resolve()
     return {
+      waitChange: () => resolved,
       waitIdle: async () => await buildPromise,
       close() {},
     }
+  }
 }
 
 function runChildProcess(name) {

--- a/lib/services/monitor.js
+++ b/lib/services/monitor.js
@@ -15,6 +15,16 @@ const parseExtensions = source =>
         .map(s => s.trim())
         .map(prefixDot)
 
+const Deferred = () => {
+  let resolve
+  let reject
+  const promise = new Promise((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+  return { promise, resolve, reject }
+}
+
 // must resolve when the initial routes have been generated (aka system ready)
 module.exports = function monitor(options, callback) {
   const {
@@ -36,6 +46,8 @@ module.exports = function monitor(options, callback) {
 
   // run generate in series
   let idlePromise
+  // change event is needed for rollup plugin
+  let changeDeferred = Deferred()
   // dedup multiple calls to generate while busy
   let scheduled = false
 
@@ -45,9 +57,15 @@ module.exports = function monitor(options, callback) {
     if (scheduled) return
     try {
       scheduled = true
+      // waitChange must defer until idlePromise is current (which is now)
+      changeDeferred.resolve()
       await idlePromise
       idlePromise = callback(event)
       await idlePromise
+      // until this point, we don't need to block waiting for change, because
+      // idlePromise will wait all what is needed, so we leave the resolved
+      // changeDeferred.promise until here
+      changeDeferred = Deferred()
     } finally {
       scheduled = false
     }
@@ -79,6 +97,8 @@ module.exports = function monitor(options, callback) {
   watch.init().catch(err => {
     log.error('Failed to watch pages directory', err)
   })
+
+  watch.waitChange = async () => await changeDeferred.promise
 
   watch.waitIdle = async () => await idlePromise
 

--- a/plugins/rollup.js
+++ b/plugins/rollup.js
@@ -1,8 +1,12 @@
 const { name } = require('../package.json')
 const { start } = require('../lib/services/interface')
 
+const wait = delay => new Promise(resolve => setTimeout(resolve, delay))
+
 module.exports = function svelteFileRouter(inputOptions) {
-  const { waitIdle, close } = start({
+  const { watchDelay } = inputOptions
+
+  const { waitIdle, waitChange, close } = start({
     watch: process.env.ROLLUP_WATCH,
     ...inputOptions,
   })
@@ -16,6 +20,50 @@ module.exports = function svelteFileRouter(inputOptions) {
     //      renderStart is probably better suited to our purpose anyway)
     //
     async renderStart() {
+      // watchDelay option
+      //
+      // this is intented to prevent a nasty race with
+      // rollup-plugin-hot/autoccreate
+      //
+      // autocreate plugin is needed for HMR stability because Rollup crashes
+      // and can't recover when it tries to import a missing file. autocreate
+      // mitigates this by creating empty missing files; thus allowing Rollup
+      // to keep humming
+      //
+      // the race however goes like this:
+      //
+      // - user rename/delete page file
+      // - rollup picks file change
+      // - rollup triggers build
+      // - rollup-plugin-hot/autocreate sees deleted file in routes.js
+      // - autocreate recreates just deleted file <--- HERE BE BUG
+      // - routify picks file change
+      // - routify recreates routes.js
+      // - ... but too late, user has extraneous deleted file recreated
+      // - rollup picks the change in routes.js...
+      //
+      // this delay is intented to give some time to routify to pick the
+      // change first (and so rollup plugin will block start of rollup build
+      // until routes.js has been generated)
+      //
+      // we can't be too greedy, because this delay will be paid for _any_
+      // file change when user is working, even when unneeded (and in this
+      // case the delay will be consumed in full -- nominal case is worst
+      // case) :-/
+      //
+      // 20ms seems to work on my machine
+      //
+      if (watchDelay) {
+        // we stop waiting early if Routify has caught the change (waitChange)
+        // -- this ensures optimal waiting time but, unfortunately, in the
+        // marginal case of when user deletes/renames a Routify page file; we're
+        // stil degenerate (i.e. wait full delay) for any other source watched
+        // by Rollup...
+        await Promise.race([wait(watchDelay), waitChange()])
+      }
+
+      // prevent build from starting until Routify has finished generating
+      // routes.js (or Rollup would do a useless build with stalled routes.js)
       await waitIdle()
     },
 


### PR DESCRIPTION
That's mostly self serving because the bug is realized when used alongside `rollup-plugin-hot/autocreate`.

In short, if Rollup catches a file change event before Routify, then Routify's plugin won't defer Rollup's build ('cause it doesn't know yet it will have too), and so Rollup will build with an outdated `routes.js`.

This PR introduces an option for an arbitrary delay, that greatly increase the probability that Routify has the time to catch the FS event first (thus, it will then hold Rollup on while regenerating `routes.js`).