### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,32 @@
 
 
 
-
 ## Install
-``npm i @sveltech/routify`` or clone the [starter template](https://github.com/sveltech/routify-starter)
+
+See our getting started page: https://2020-routify.now.sh/introduction/getting-started
 
 For the old version (svelte-filerouter), please go [here](https://github.com/sveltech/routify/tree/v1)
 
 ## Documentation
-[routify.dev](https://routify.dev/docs/introduction)
+
+https://2020-routify.now.sh/docs/
 
 ## Template
+
 [Routify starter template](https://github.com/sveltech/routify-starter)
+
 Includes SSR, prerendering, code splitting and much more.
 
 ## Example
+
 [Starter example](https://example.routify.dev/example) Example from the starter template. Refresh a page to see how it is loaded.
 
 ## Tutorials
+
 [Easy client-side SPA routing with Routify](https://www.youtube.com/watch?v=AGLUJlOC6f0) by Jitesh
 
 ## Support
+
 Please feel free to open an issue or a pull request. All feedback is welcome.
 
 <img height="32px" src="https://discordapp.com/assets/f8389ca1a741a115313bede9ac02e2c0.svg" /> **Join us on Discord** 


### PR DESCRIPTION
Should maybe not link to old resources here, but would help if we can just put the new site on routify.dev and use that as the main URL for everything. What do you think?