### PR TITLE
feat(build hooks) bring experimental hooks back

### DIFF
--- a/lib/services/scanner.js
+++ b/lib/services/scanner.js
@@ -7,6 +7,7 @@ const { addPath, addId, removeUnderscoredDirs, removeNonSvelteFiles, sortTree, d
 const {
   pipeAsync,
   walkAsync,
+  identity,
 } = require('../utils/fp')
 
 
@@ -40,20 +41,22 @@ module.exports = async function scanner(inputOptions, metaParser) {
   const buildTree = pipeAsync(
     generateFileTree(options), // => dir
     createRoot, // dir => ({ dir, ...root })
+    walkAsync(hooks.file),
+    hooks.tree || identity,
     removeUnderscoredDirs, // _private => false
     defineFiles, // file => ({ isLayout, isReset, isIndex, isFallback })
     removeNonSvelteFiles, // remove _file.svelte, keep dirs, layouts & resets
     applyMetaToFiles({ metaParser }),
     applyMetaToTree(defaultMeta),
     addPath, // ... => ({ path, ... })
+    walkAsync(hooks.decorate),
     addId, // ... => ({ id, ... })
+    // TODO sortTree became useless apparently -- keeping it a little longer
+    // sortTree, 
     // NOTE "walkers" will be called for each file (not the whole tree)
     walkAsync(
-      // hooks.readTree, // file => void|false
-      // TODO sortTree became useless apparently -- keeping it a little longer
-      // ), sortTree, walkAsync(
-      // hooks.decorate,
-      attachComponent(options) // { component }; { path } for layouts
+      attachComponent(options), // { component }; { path } for layouts
+      hooks.finalize,
     )
   )
 


### PR DESCRIPTION
Comeback of the Svench hooks. Still no special attachment to the names or the way they should be registered by the user. The point here is to illustrate what would be needed.

Until some decisions are taken, I'd appreciate if we can keep them in the beta codebase (not necessarily with you preserving them in your refactors, I can PR ad nauseam)... If that bothers you, I can use Routify from a custom branch though, so not too important.

For some context:

The `file` hook does some customization of file names (e.g. drop `.svench` suffix from directory, replace `.` with `/` to allow collocation of a svench file with the component it documents...).

`tree` relocates nodes with changed filepath to their correct position in the tree. This needs to be done in a subsequent hook, because we need to be sure that file name customization is finished before we relocate nodes.

`decorate` customize the file `path` (the one sent to the client), and extract some metas from some special filename patterns.

And `finalize` generates a unique `id` for each node (even dirs), which uses both `path` and `id` from the node.

## Notes

### User hooks pattern

I wonder if a good pattern for (some of the) user hooks could be to have specific hooks for some of the notable props that are added to the file object by the pipeline. Something like this:

```js
hooks: {
  filepath: file => filepath,
  id: file => id,
  ...
}
```

This adds some visibility as to what prop appears when to the user, and it would allow Routify to implement tree reorganization itself (since it knows when the filepath can't change anymore). Just an idea...

### Mixed file / dir node

One of the consequence of changing file paths and restructuring the tree accordingly is that some page can become children of other pages, not just dir.

This can not happen with actual FS, of course (a file can't be both a file and a dir), but it doesn't seem to break Routify if we let it pass. We just need to rely on prop that `dir` to know if a node points to a file (irrelevant of if it has children or not). See my next PR.