### PR TITLE
feat(tree) add isFile prop to allow pages to have children

### DIFF
--- a/lib/services/_template.js
+++ b/lib/services/_template.js
@@ -18,7 +18,7 @@ module.exports = function template(tree, options) {
     dir.forEach(file => {
       if (file.dir)
         getImports(file.dir, imports, false)
-      else if (file.meta.preload || !dynamicImports)
+      if (file.isFile && (file.meta.preload || !dynamicImports))
         imports.push(file)
     })
     return imports

--- a/lib/services/middleware/attachComponent.js
+++ b/lib/services/middleware/attachComponent.js
@@ -2,7 +2,7 @@ const path = require('path')
 
 function attachComponent({ dynamicImports, pages, routifyDir }) {
     return function (file) {
-        if (!file.dir) {
+        if (file.isFile) {
             const { $$bundleId } = file.meta
             let component
             if (dynamicImports && !file.meta.preload) {

--- a/lib/services/middleware/basic.js
+++ b/lib/services/middleware/basic.js
@@ -16,7 +16,7 @@ const addPath = walkAsync(function addPath(file) {
 })
 
 const addId = walkAsync(function addId(file) {
-  if (!file.dir) {
+  if (file.isFile) {
     file.id = makeLegalIdentifier(file.path)
   }
 })

--- a/lib/services/middleware/generateFileTree.js
+++ b/lib/services/middleware/generateFileTree.js
@@ -36,6 +36,7 @@ const generateFileTree = ({ ignore, extensions }) => {
                     if (badExt) return false
 
                     const file = {
+                        isFile: !isDir,
                         file: filename,
                         filepath,
                         name,
@@ -63,7 +64,6 @@ async function isDirectory(file, fsa) {
     const stat = await fsa.stat(file)
     return stat.isDirectory()
   }
-  
 
 module.exports = { generateFileTree }
 
@@ -71,4 +71,3 @@ function isAcceptedDir({ name, filepath }, isDir, isIgnored) {
     const isUnderscored = name.match(/^_/)
     return isDir && !isUnderscored && !isIgnored(filepath)
   }
-  

--- a/runtime/buildRoutes.js
+++ b/runtime/buildRoutes.js
@@ -29,14 +29,14 @@ const decorateRoute = function (route) {
  */
 function flattenTree(tree, arr = []) {
   tree.forEach(file => {
+    if (file.isFile) arr.push(file)
     if (file.children) arr.push(...flattenTree(file.children))
-    else arr.push(file)
   })
   return arr
 }
 
 export function buildClientTree(file, parent = false, prevFiles = []) {
-  
+
   const _prevFiles = []
   if (file.dir) {
     file.children = file.dir
@@ -59,6 +59,7 @@ export function buildClientTree(file, parent = false, prevFiles = []) {
     "setPrototype",
   ]
 
+  // eslint-disable-next-line import/namespace
   order.forEach(plugin => plugins[plugin]({ file, parent, prevFiles }));
 
   return file

--- a/runtime/plugins/tree.js
+++ b/runtime/plugins/tree.js
@@ -41,7 +41,7 @@ export function setPrototype({ file }) {
     const Prototype = !file.parent
         ? Root
         : file.children
-            ? Dir
+            ? file.isFile ? PageDir : Dir
             : file.isReset
                 ? Reset
                 : file.isLayout
@@ -55,6 +55,7 @@ export function setPrototype({ file }) {
     function Dir() { }
     function Fallback() { }
     function Page() { }
+    function PageDir() { }
     function Reset() { }
     function Root() { }
 }
@@ -82,4 +83,3 @@ function _prettyName(file) {
             .pop()
             .replace(/-/g, ' ')
 }
-


### PR DESCRIPTION
Proposed solution to allow a tree node to act both as a directory (i.e. have children), and as a file (i.e. points to a page component).

- add a `isFile` prop when we still have the information

- use `file.isFile` instead of `!file.dir` to know if a node points to an actual file (i.e. component)

- in some places, allow behaviours both for children (`dir`) and page (`isFile`)

This is not needed with the real FS, since a file can't be a directory, but this is useful if we allow users to temper with file paths / the tree.