### PR TITLE
fix Router / navigator init in weird edge case

### DIFF
--- a/runtime/Router.svelte
+++ b/runtime/Router.svelte
@@ -2,7 +2,7 @@
   import { setContext, onDestroy } from 'svelte'
   import Route from './Route.svelte'
   import { init } from './navigator.js'
-  import { routes as routesStore } from './store.js'
+  import { route, routes as routesStore } from './store.js'
   import { suppressWarnings } from './utils.js'
   import defaultConfig from '../runtime.config'
 
@@ -60,6 +60,6 @@
   onDestroy(cleanup)
 </script>
 
-{#if layouts}
+{#if layouts && $route !== null}
   <Route {layouts} />
 {/if}

--- a/runtime/Router.svelte
+++ b/runtime/Router.svelte
@@ -34,11 +34,25 @@
     navigator = null
   }
 
+  let initTimeout = null
+
+  // init is async to prevent a horrible bug that completely disable reactivity
+  // in the host component -- something like the component's update function is
+  // called before its fragment is created, and since the component is then seen
+  // as already dirty, it is never scheduled for update again, and remains dirty
+  // forever... I failed to isolate the precise conditions for the bug, but the
+  // faulty update is triggered by a change in the route store, and so offseting
+  // store initialization by one tick gives the host component some time to
+  // create its fragment. The root cause it probably a bug in Svelte with deeply
+  // intertwinned store and reactivity.
   const doInit = () => {
-    cleanup()
-    navigator = init(routes, callback)
-    routesStore.set(routes)
-    navigator.updatePage()
+    clearTimeout(initTimeout)
+    initTimeout = setTimeout(() => {
+      cleanup()
+      navigator = init(routes, callback)
+      routesStore.set(routes)
+      navigator.updatePage()
+    })
   }
 
   $: if (routes) doInit()

--- a/runtime/store.js
+++ b/runtime/store.js
@@ -1,6 +1,6 @@
 import { writable, derived } from 'svelte/store'
 
-export const route = writable({}) // the actual route being rendered
+export const route = writable(null) // the actual route being rendered
 export const routes = writable([]) // all routes
 export const urlRoute = writable({})  // the route matching the url
 export const basepath = writable("") // basepath regex


### PR DESCRIPTION
I've been facing a horrible bug where any subscribing to the `route` store during init of the component that host the `<Router />` completely disables reactivity in this component. I failed to create a simple repro, but I traced the cause to a call to the component's update function that is made too early, and that is triggered by setting the value of the `route` store during Router > navigator init. Deferring the navigator init by one tick solves the issue...

Also, I suggest to use a `null` default value for `route` instead of a dummy `{}`, and instead wait that the route is ready before rendering anything. It's safer that letting a useless round of rendering go, and hope that nothing down the line will try, for example, to read a `$route.sub.prop` before the route is initialized. Also, since we currently have no "route changed" event, the `$route` store is kind of a stopgap solution for it, and the dummy object makes it hard to know that `$route` is not ready yet. Having `null` makes it unambiguous.