### PR TITLE
fix: Close file watchers for non-watching rollup build

### DIFF
--- a/plugins/rollup.js
+++ b/plugins/rollup.js
@@ -7,7 +7,7 @@ module.exports = function svelteFileRouter(inputOptions) {
   const { watchDelay } = inputOptions
 
   const { waitIdle, waitChange, close } = start({
-    watch: process.env.ROLLUP_WATCH,
+    singleBuild: !process.env.ROLLUP_WATCH,
     ...inputOptions,
   })
 


### PR DESCRIPTION
Fixes https://github.com/sveltech/routify/issues/145