### PR TITLE
fix: update link to starter example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Includes SSR, prerendering, code splitting and much more.
 
 ## Example
 
-[Starter example](https://example.routify.dev/example) Example from the starter template. Refresh a page to see how it is loaded.
+[Starter example](https://routify-starter.now.sh/example) Example from the starter template. Refresh a page to see how it is loaded.
 
 ## Tutorials
 


### PR DESCRIPTION
It seems that the [routify-starter](https://github.com/sveltech/routify-starter) currently links the example to the now URL: https://routify-starter.now.sh/example rather than the https://example.routify.dev/example currently linked in the README.md.