### PR TITLE
attempting getContext before setContext

### DIFF
--- a/runtime/Route.svelte
+++ b/runtime/Route.svelte
@@ -41,12 +41,11 @@
 
   const context = writable(null)
 
-  /** @type {import("svelte/store").Writable<Context>} */
-  const parentContextStore = getContext('routify')
-
-
   isDecorator = Decorator && !childOfDecorator
   setContext('routify', context)
+  
+  /** @type {import("svelte/store").Writable<Context>} */
+  const parentContextStore = getContext('routify')
 
   $: if (isDecorator) {
     const decoratorLayout = {


### PR DESCRIPTION
1. After upgrading to version 1.7.11, i get an error ("store is undefined"), when loading routes. which i can track back to this line...

https://github.com/sveltech/routify/blob/3faaa871827d6c9c64b2830a0dfd1481fe6c7087/runtime/Route.svelte#L71

if you look up to line 46 and line 49, you will see that it calls `getContext` before `setContext` - so the variable set by getContext is undefined. im not sure how this would ever work - but i probably don't understand svelte context properly!

2. I checked out our last used version of routify 1.5.0 - and i no longer get the error.

sure enough, the scenario i described above is not the case in this version...
https://github.com/sveltech/routify/blob/fe9cca1231491b0de26b56568332ce02a4ed4243/runtime/Route.svelte#L34
setContext is called... and getContext is not called before it 

Here is where we use Routify: https://github.com/Budibase/budibase/blob/master/packages/builder/src/App.svelte

This PR fixes our issue... unforunately I was noo able to check if tests are running - node-gyp was complaining on my machine, which happens to me alot :(