### PR TITLE
Move sorting of child pages to build time.

### DIFF
--- a/lib/middleware/defaultSort.js
+++ b/lib/middleware/defaultSort.js
@@ -1,0 +1,33 @@
+const LC_OPTS = { numeric: true, sensitivity: 'base' }
+
+module.exports = sort
+
+function sort(payload) {
+  const { tree, options } = payload
+  const comparer = (options || {}).compareSiblings || compareFiles
+  sortChildren(tree, comparer)
+}
+
+function sortChildren(parent, comparer) {
+  if (!parent.children || !parent.children.length) { return }
+  parent.children.sort(comparer)
+  for (const child of parent.children) {
+    sortChildren(child, comparer)
+  }
+}
+
+function compareFiles(a, b) {
+  if (a.isMeta && b.isMeta) { return 0 }
+  // Sort by index first
+  const indexDiff = (a.meta.index || 0) - (b.meta.index || 0)
+  if (indexDiff === 0) {
+    // Index same, sort by title
+    const titleDiff = (a.meta.title || '').localeCompare((b.meta.title || ''), undefined, LC_OPTS)
+    if (titleDiff === 0) {
+      // Title same, sort by path
+      return a.path.localeCompare(b.path, undefined, LC_OPTS)
+    }
+    return titleDiff
+  }
+  return indexDiff
+}

--- a/lib/services/middlewareRunner.js
+++ b/lib/services/middlewareRunner.js
@@ -7,7 +7,7 @@ const { pipeAsync } = require('../utils/fp')
 const log = require('../utils/log')
 const createBundles = require('../middleware/createBundles')
 const writeUrlIndex = require('../middleware/writeUrlIndex')
-
+const defaultSort = require('../middleware/defaultSort')
 // @ts-check
 
 /**
@@ -28,6 +28,7 @@ module.exports = async function middlewareRunner(payload) {
     applyMetaToTree,
     addPath, // ... => ({ path, ... })
     addId, // ... => ({ id, ... })
+    defaultSort,
     attachComponent, // { component }; { path } for layouts
     template,
     createBundles,
@@ -49,7 +50,7 @@ async function applyExtensions(payload = [], middlewares) {
   const plugins = payload.options.plugins || {}
   
 
-  for (plugin of Object.entries(plugins)) {
+  for (const plugin of Object.entries(plugins)) {
     const [name, config] = plugin
     const pluginFn = resolveExtension(name)
     if (!pluginFn) { log.error(`did not find the extension ${name}`); process.exit(); }
@@ -64,7 +65,7 @@ function resolveExtension(name) {
   const localPath = resolve(__dirname, '../extensions', name)
   const cwdModule = resolve(process.cwd(), 'node_modules', name)
 
-  for (path of [cwdPath, localPath, cwdModule, name]) {
+  for (const path of [cwdPath, localPath, cwdModule, name]) {
     try {
       return require(path)
     } catch (err) {

--- a/runtime/plugins/assignAPI.js
+++ b/runtime/plugins/assignAPI.js
@@ -17,12 +17,6 @@ class ClientApi {
     get children() {
         return (this.__file.children || this.__file.isLayout && this.__file.parent.children || [])
             .filter(c => !c.isNonIndexable)
-            .sort((a, b) => {
-                if(a.isMeta && b.isMeta) return 0
-                a = (a.meta.index || a.meta.title || a.path).toString()
-                b = (b.meta.index || b.meta.title || b.path).toString()
-                return a.localeCompare((b), undefined, { numeric: true, sensitivity: 'base' })
-            })
             .map(({ api }) => api)
     }
     get next() { return _navigate(this, +1) }


### PR DESCRIPTION
Here is the change to sort child pages at build time. I've changed the sorting logic slightly to sort on `index`, `title` and `path` separately. This supports negative indexes properly.

Also, I've created a hook to provide an alternative sort method in the config file if desired. Not sure if this is something you want to have, if not, it is easy to remove.

Also I'm not sure what state the unit tests are in, they don't seem to run. I have tested the changes manually.