### PR TITLE
Use proper config param for routifyDir

### DIFF
--- a/lib/services/exporter.js
+++ b/lib/services/exporter.js
@@ -7,8 +7,8 @@ const defaults = require('../../config.defaults.json')
 const { ssr } = require('@sveltech/ssr')
 
 module.exports.exporter = async function exporter(params) {
+    params.routifyDir = params.routes; // From commandline library
     params = { ...defaults, ...config, ...params }
-
     const distDir = getAbsolutePath(params.distDir)
     const routesPath = getAbsolutePath(params.routifyDir, 'urlIndex.js')
     const basepaths = params.basepath


### PR DESCRIPTION
If you use a custom `routifyDir` it doesn't work on export without this.