### PR TITLE
fix: hash validation on handleHash function

### DIFF
--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -1,30 +1,33 @@
 const MATCH_PARAM = RegExp(/\:([^/()]+)/g)
 
-export function handleScroll(element) {
+export function handleScroll (element) {
   if (navigator.userAgent.includes('jsdom')) return false
   scrollAncestorsToTop(element)
   handleHash()
 }
 
-export function handleHash() {
+export function handleHash () {
   if (navigator.userAgent.includes('jsdom')) return false
   const { hash } = window.location
   if (hash) {
-    const el = document.querySelector(hash)
-    if (hash && el) el.scrollIntoView()
+    const validElementIdRegex = /^[A-Za-z]+[\w\-\:\.]*$/
+    if (validElementIdRegex.test(hash)) {
+      const el = document.querySelector(hash)
+      if (hash && el) el.scrollIntoView()
+    }
   }
 }
 
-export function scrollAncestorsToTop(element) {
+export function scrollAncestorsToTop (element) {
   if (
     element &&
     element.scrollTo &&
     element.dataset.routify !== 'scroll-lock' &&
     element.dataset['routify-scroll'] !== 'lock'
   ) {
-    element.style['scroll-behavior'] = "auto"
+    element.style['scroll-behavior'] = 'auto'
     element.scrollTo({ top: 0, behavior: 'auto' })
-    element.style['scroll-behavior'] = ""
+    element.style['scroll-behavior'] = ''
     scrollAncestorsToTop(element.parentElement)
   }
 }
@@ -40,8 +43,7 @@ export const pathToRegex = (str, recursive) => {
 export const pathToParamKeys = string => {
   const paramsKeys = []
   let matches
-  while (matches = MATCH_PARAM.exec(string))
-    paramsKeys.push(matches[1])
+  while ((matches = MATCH_PARAM.exec(string))) paramsKeys.push(matches[1])
   return paramsKeys
 }
 
@@ -56,7 +58,7 @@ export const pathToRank = ({ path }) => {
 let warningSuppressed = false
 
 /* eslint no-console: 0 */
-export function suppressWarnings() {
+export function suppressWarnings () {
   if (warningSuppressed) return
   const consoleWarn = console.warn
   console.warn = function (msg, ...msgs) {
@@ -70,8 +72,7 @@ export function suppressWarnings() {
   warningSuppressed = true
 }
 
-
-export function currentLocation() {
+export function currentLocation () {
   const pathMatch = window.location.search.match(/__routify_path=([^&]+)/)
   const prefetchMatch = window.location.search.match(/__routify_prefetch=\d+/)
   window.routify = window.routify || {}

--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -13,7 +13,7 @@ export function handleHash () {
     const validElementIdRegex = /^[A-Za-z]+[\w\-\:\.]*$/
     if (validElementIdRegex.test(hash)) {
       const el = document.querySelector(hash)
-      if (hash && el) el.scrollIntoView()
+      if (el) el.scrollIntoView()
     }
   }
 }


### PR DESCRIPTION
Added validation to the `handleHash` function to ensure the hash fragment being handled meets the requirements for a valid element id before attempting to query the element using the hash fragment.

This PR fixes #233 

I haven't added tests, as I couldn't see where you had unit tests. Happy to add tests with some guidance on how best to do so.

