### PR TITLE
fix: ensure hash validation doesn't use hashtag

### DIFF
--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -11,7 +11,7 @@ export function handleHash () {
   const { hash } = window.location
   if (hash) {
     const validElementIdRegex = /^[A-Za-z]+[\w\-\:\.]*$/
-    if (validElementIdRegex.test(hash)) {
+    if (validElementIdRegex.test(hash.substring(1))) {
       const el = document.querySelector(hash)
       if (el) el.scrollIntoView()
     }


### PR DESCRIPTION
So sorry about this! I just realised my last PR broke the intended functionality of the `handleHash` function. I tested that it fixed my error, but didn't ensure it didn't break intended functionality. So so sorry!

Basically a hashtag is not a valid character in an element ID, so any string with a hashtag in it with fail the regex test I included in the last PR. But `window.location.hash` will always return the hash fragment including the hashtag (https://www.w3schools.com/jsref/prop_loc_hash.asp) and `document.querySelector` will work with a hashtag included in the selector passed to it (https://www.w3schools.com/jsref/met_document_queryselector.asp).

The regex test I put in was ensuring valid hash fragments weren't being processed. I've updated the comparison to ensure it doesn't include the leading hashtag in the string it tests against. I have tested this on the project I'm working on and it restores the intended functionality, whilst removing the error I was getting.

So sorry about this!