### PR TITLE
fix: add missing dependency chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@sveltech/ssr": "^0.0.11",
     "@types/node": ">=4.2.0 < 13",
+    "chalk": "^4.0.0",
     "cheap-watch": "^1.0.2",
     "commander": "^5.0.0",
     "dotenv": "^8.2.0",
@@ -41,7 +42,6 @@
   },
   "devDependencies": {
     "@sveltech/routify": "*",
-    "chalk": "^4.0.0",
     "chokidar-cli": "^2.1.0",
     "del-cli": "^3.0.0",
     "memfs": "^3.0.3",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@sveltech/routify` depends on `chalk` but doesn't declare it as a dependency

**How did you fix it?**

Move `chalk` from `devDependencies` to `dependencies`