### PR TITLE
fix: point Router type in index.d.ts to Router.svelte

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 declare module '@roxi/routify' {
   export * from '@roxi/routify/typings/runtime/helpers'
   export * from '@roxi/routify/typings/runtime/store'
-  export const Router: import('svelte/internal').SvelteComponent
+  export const Router: typeof import('./runtime/Router.svelte').default
   export const routify: typeof import('@roxi/routify/plugins/rollup')
 
   global {


### PR DESCRIPTION
Fixes https://github.com/roxiness/routify/issues/248.