### PR TITLE
Fix static Goto/Redirect not working after component initialization

### DIFF
--- a/runtime/Router.svelte
+++ b/runtime/Router.svelte
@@ -3,7 +3,7 @@
   import Route from './Route.svelte'
   import Prefetcher from './Prefetcher.svelte'
   import { init } from './navigator.js'
-  import { route, routes as routesStore, prefetchPath } from './store.js'
+  import { route, routes as routesStore, prefetchPath, routeNavigator as navigator } from './store.js'
   import { suppressWarnings } from './utils'
   import defaultConfig from '../runtime.config'
 
@@ -11,7 +11,6 @@
   export let config = {}
 
   let nodes
-  let navigator
 
   window.routify = window.routify || {}
   window.routify.inBrowser = !window.navigator.userAgent.match('jsdom')
@@ -20,16 +19,12 @@
 
   suppressWarnings()
 
-  const updatePage = (...args) => navigator && navigator.updatePage(...args)
-
-  setContext('routifyupdatepage', updatePage)
-
   const callback = res => (nodes = res)
 
   const cleanup = () => {
-    if (!navigator) return
-    navigator.destroy()
-    navigator = null
+    if (!$navigator) return
+    $navigator.destroy()
+    $navigator = null
   }
 
   let initTimeout = null
@@ -47,9 +42,9 @@
     clearTimeout(initTimeout)
     initTimeout = setTimeout(() => {
       cleanup()
-      navigator = init(routes, callback)
+      $navigator = init(routes, callback)
       routesStore.set(routes)
-      navigator.updatePage()
+      $navigator.updatePage()
     })
   }
 

--- a/runtime/store.js
+++ b/runtime/store.js
@@ -11,6 +11,9 @@ export const route = writable(null) // the actual route being rendered
 export const routes = writable([]) // all routes
 routes.subscribe(routes => (window.routify.routes = routes))
 
+/** @type {import('svelte/store').Writable<RouteNavigator>} */
+export const routeNavigator = writable(null);
+
 export let rootContext = writable({ component: { params: {} } })
 
 /** @type {import('svelte/store').Writable<RouteNode>} */

--- a/typings/typedef.d.ts
+++ b/typings/typedef.d.ts
@@ -60,6 +60,13 @@ type ClientNodeApi = {
     } & DefinedFile & ClientNodeSpecifics;
 };
 /**
+ * Navigation
+ */
+type RouteNavigator = {
+    updatePage(): (proxyToUrl: any, shallow: any) => Promise<void>,
+    destroy(): void
+}
+/**
  * File
  */
 type RouteNode = {


### PR DESCRIPTION
With the actual previous approach `$goto` and `$redirect` could not be used asynchronously **with `static`enabled** due to Svelte being unable to use `getContext()` after component initialization.

This new approach stores the navigator as an observable (writable) and it gets feed directly into `goto` and `redirect` derived subscriptions so they can be used if needed.

As an example, A use case where this functionality is required:
_One end user performs a wizard of 3 steps, during the 2nd step, there is a button to open a Help page, if the user refresh the page or the user wants to share the wizard, the Help page URL will be the one appearing instead of the Wizard on step 2. In order to avoid the Help page to break the workflow of the url with the wizard, or to hide irrelevant endpoint routes, `static` mode requires to be true, but it does not work when the redirection is asynchronous after components has been loaded_

PD: there might be a small detail missing on the type definition as I didn't manage to see the property inferred by my IDE (it was saying 'any'). Typedef is a bit complex here for me to understand.