### PR TITLE
Get rid of false warning on the browser's console

### DIFF
--- a/runtime/decorators/Noop.svelte
+++ b/runtime/decorators/Noop.svelte
@@ -1,5 +1,5 @@
 <script>
-  export let scoped = "";
+  export let scoped = {};
 </script>
 
 <slot/>

--- a/runtime/decorators/Noop.svelte
+++ b/runtime/decorators/Noop.svelte
@@ -1,1 +1,5 @@
+<script>
+  export let scoped = "";
+</script>
+
 <slot/>


### PR DESCRIPTION
I keep seeing this warning `<Noop> was created with unknown prop 'scoped'`. The proposed minor change here eliminates it.