### PR TITLE
Fix: rollup warning caused by the previous change

### DIFF
--- a/runtime/decorators/Noop.svelte
+++ b/runtime/decorators/Noop.svelte
@@ -1,5 +1,6 @@
 <script>
   export let scoped = {};
+  scoped;
 </script>
 
 <slot/>


### PR DESCRIPTION
When running `npm run rollup` I get:
```
(!) Plugin svelte: Noop has unused export property 'scoped'. If it is for external reference only, please consider using `export const scoped`
node_modules/@roxi/routify/runtime/decorators/Noop.svelte
1: <script>
2:   export let scoped = {};
                ^
```
The suggested one-liner eliminates that warning.