### PR TITLE
fix: add typing for SvelteActionReturnType to UrlHelper

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "test": "cd test && ava tests/** --timeout 300s",
     "test:cli": "cd test && ava tests/cli/** --timeout 300s",
     "test:e2e": "start-server-and-test start:example 5000 \"cd test && npm install && npx ava tests/e2e/** --watch\"",
-    "test:mock-api": "cd test && ava tests/mock-server/**"
+    "test:mock-api": "cd test && ava tests/mock-server/**",
+    "test:typings": "tsc --noEmit",
+    "build:typings": "tsc --project ./tsconfig.typings.json"
   },
   "prettier": {
     "semi": false,

--- a/runtime/helpers.js
+++ b/runtime/helpers.js
@@ -1,10 +1,10 @@
-import { getContext, tick } from 'svelte'
-import { derived, get, writable } from 'svelte/store'
-import { route, routes, rootContext, isChangingPage } from './store'
-import { resolveUrl } from './utils'
-import { onPageLoaded } from './utils/onPageLoaded.js'
-import { urlToRoute } from './utils/urlToRoute'
-import { prefetch as _prefetch } from './Prefetcher.svelte'
+import {getContext, tick} from 'svelte'
+import {derived, get, writable} from 'svelte/store'
+import {route, routes, rootContext, isChangingPage} from './store'
+import {resolveUrl} from './utils'
+import {onPageLoaded} from './utils/onPageLoaded.js'
+import {urlToRoute} from './utils/urlToRoute'
+import {prefetch as _prefetch} from './Prefetcher.svelte'
 /// <reference path="../typedef.js" />
 
 /** @ts-check */
@@ -95,10 +95,10 @@ export const ready = {
     window['routify'].stopAutoReady = true
     async function ready() {
       await tick()
-      await onPageLoaded({ page: get(route), metatags, afterPageLoad })
+      await onPageLoaded({page: get(route), metatags, afterPageLoad})
     }
     run(ready)
-    return () => { }
+    return () => {}
   }
 }
 
@@ -131,7 +131,7 @@ export const beforeUrlChange = {
 function hookHandler(listener) {
   const hooks = this._hooks
   const index = hooks.length
-  listener(callback => { hooks[index] = callback })
+  listener(callback => {hooks[index] = callback})
   return (...params) => {
     delete hooks[index]
     listener(...params)
@@ -196,16 +196,14 @@ export const meta = {
 }
 
 /**
- * @callback UrlHelper
- * @param {String=} path
- * @param {UrlParams=} params
- * @param {UrlOptions=} options
- * @return {String}
- *
+ * @typedef {{
+ *   (el: Node): {update: (args: any) => void;}
+ *   (path?: string | undefined, params?: UrlParams | undefined, options?: UrlOptions | undefined): string;
+ * }} UrlHelper
  * @typedef {import('svelte/store').Readable<UrlHelper>} UrlHelperStore
  * @type {UrlHelperStore} 
  * */
- export const url = {
+export const url = {
   subscribe(listener) {
     const ctx = getRoutifyContext()
     return derived(
@@ -225,7 +223,7 @@ export const meta = {
  */
 export function makeUrlHelper($ctx, $currentRoute, $routes) {
   return function url(path, params = {}, options) {
-    const { component } = $ctx
+    const {component} = $ctx
     const inheritedParams = Object.assign({}, $currentRoute.params, component.params)
     let el = path && path.nodeType && path
 
@@ -251,7 +249,7 @@ export function makeUrlHelper($ctx, $currentRoute, $routes) {
     if (el) {
       el.href = url
       return {
-        update(changedParams) { el.href = resolveUrl(path, changedParams, inheritedParams) }
+        update(changedParams) {el.href = resolveUrl(path, changedParams, inheritedParams)}
       }
     }
 
@@ -341,13 +339,13 @@ export const redirect = {
  * @typedef {import('svelte/store').Readable<IsActiveHelper>} IsActiveHelperStore
  * @type {IsActiveHelperStore} 
  * */
- export const isActive = {
+export const isActive = {
   subscribe(run) {
     return derived(
       [url, route],
-      ([url, route]) => function isActive(path = "", params = {}, { strict } = { strict: true }) {
-        path = url(path, params, { strict })
-        const currentPath = url(route.path, params, { strict })
+      ([url, route]) => function isActive(path = "", params = {}, {strict} = {strict: true}) {
+        path = url(path, params, {strict})
+        const currentPath = url(route.path, params, {strict})
         const re = new RegExp('^' + path + '($|/)')
         return !!currentPath.match(re)
       }
@@ -438,9 +436,9 @@ const _metatags = {
   props: {},
   templates: {},
   services: {
-    plain: { propField: 'name', valueField: 'content' },
-    twitter: { propField: 'name', valueField: 'content' },
-    og: { propField: 'property', valueField: 'content' },
+    plain: {propField: 'name', valueField: 'content'},
+    twitter: {propField: 'name', valueField: 'content'},
+    og: {propField: 'property', valueField: 'content'},
   },
   plugins: [
     {
@@ -489,7 +487,7 @@ const _metatags = {
     const head = document.getElementsByTagName('head')[0]
     const match = prop.match(/(.+)\:/)
     const serviceName = match && match[1] || 'plain'
-    const { propField, valueField } = metatags.services[serviceName] || metatags.services.plain
+    const {propField, valueField} = metatags.services[serviceName] || metatags.services.plain
     const oldElement = document.querySelector(`meta[${propField}='${prop}']`)
     if (oldElement) oldElement.remove()
 
@@ -554,7 +552,7 @@ const _metatags = {
  */
 export const metatags = new Proxy(_metatags, {
   set(target, name, value, receiver) {
-    const { props } = target
+    const {props} = target
 
     if (Reflect.has(target, name))
       Reflect.set(target, name, value, receiver)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
-    "declarationDir": "typings",
-    "emitDeclarationOnly": true,
+    "noEmit": true,
     "resolveJsonModule": true,
     "moduleResolution": "Node",
     "rootDirs": ["runtime", "lib"],

--- a/tsconfig.typings.json
+++ b/tsconfig.typings.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "noEmit": false,
+    "declarationDir": "typings",
+    "emitDeclarationOnly": true
+  },
+  "extends": "./tsconfig.json",
+  "include": ["**/*.js"],
+  "exclude": [
+    "**/node_modules/*",
+    "**/*.spec.ts",
+    "test",
+    "**/tmp/*",
+    "example",
+    "**/dist/*",
+    "**/.history/*",
+    "index.d.ts"
+  ]
+}

--- a/typings/configs/meteor.config.d.ts
+++ b/typings/configs/meteor.config.d.ts
@@ -1,8 +1,8 @@
-export const name: string;
-export function condition({ pkgjson }: {
+export declare const name: string;
+export declare function condition({ pkgjson }: {
     pkgjson: any;
 }): any;
-export function config(): {
+export declare function config(): {
     pages: string;
     routifyDir: string;
 };

--- a/typings/lib/index.d.ts
+++ b/typings/lib/index.d.ts
@@ -4,4 +4,4 @@ export var routify: (inputOptions: any) => {
     renderStart(): Promise<void>;
 };
 export var getConfig: any;
-export let config: {};
+export var config: {};

--- a/typings/lib/middleware/assignMeta.d.ts
+++ b/typings/lib/middleware/assignMeta.d.ts
@@ -2,8 +2,8 @@
  * parses .svelte files for metadata and adds it to its respective node
  **/
 export const applyMetaToFiles: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 /**
  * propagate inheritable metadata to descendent nodes. $$bundleId etc.

--- a/typings/lib/middleware/attachComponent.d.ts
+++ b/typings/lib/middleware/attachComponent.d.ts
@@ -1,4 +1,4 @@
 export const attachComponent: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };

--- a/typings/lib/middleware/misc.d.ts
+++ b/typings/lib/middleware/misc.d.ts
@@ -1,17 +1,17 @@
 export const addPath: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export const addId: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export const removeUnderscoredDirs: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export function removeNonSvelteFiles(payload: any): void;
 export const defineFiles: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };

--- a/typings/lib/services/interface.d.ts
+++ b/typings/lib/services/interface.d.ts
@@ -1,6 +1,6 @@
 export function Builder(options: any, returnResult?: boolean, metaParser?: {
     get: (file: any) => Promise<{}>;
-    hasMetaChanged: (file: any) => Promise<boolean>;
+    fileChange: (file: any) => Promise<"new" | "uncached" | "changed" | "unchanged">;
     deleteFile: (file: any) => boolean;
 }): () => Promise<any>;
 export function start(inputOptions: any): {

--- a/typings/lib/services/metaParser.d.ts
+++ b/typings/lib/services/metaParser.d.ts
@@ -2,7 +2,7 @@ declare function _exports({ cache: useCache }?: {
     cache: any;
 }): {
     get: (file: any) => Promise<{}>;
-    hasMetaChanged: (file: any) => Promise<boolean>;
+    fileChange: (file: any) => Promise<"new" | "uncached" | "changed" | "unchanged">;
     deleteFile: (file: any) => boolean;
 };
 export = _exports;

--- a/typings/lib/utils/config.d.ts
+++ b/typings/lib/utils/config.d.ts
@@ -1,13 +1,2 @@
-declare function _exports(input: any): {
-    extensions: string[] | (string & any[]);
-    started: string;
-    pages: string;
-    sourceDir: string;
-    routifyDir: string;
-    ignore: string;
-    dynamicImports: boolean;
-    singleBuild: boolean;
-    noHashScroll: boolean;
-    distDir: string;
-};
+declare function _exports(input: any): any;
 export = _exports;

--- a/typings/lib/utils/fsa.d.ts
+++ b/typings/lib/utils/fsa.d.ts
@@ -1,4 +1,14 @@
-export function from(fs: any): {
+declare const _exports: {
+    from: (fs: any) => {
+        exists: (...args: any[]) => Promise<any>;
+        mkdir: Function;
+        readdir: Function;
+        stat: Function;
+        readFile: Function;
+        writeFile: Function;
+        unlink: Function;
+        realpath: Function;
+    };
     exists: (...args: any[]) => Promise<any>;
     mkdir: Function;
     readdir: Function;
@@ -8,11 +18,4 @@ export function from(fs: any): {
     unlink: Function;
     realpath: Function;
 };
-export declare function exists(...args: any[]): Promise<any>;
-export declare const mkdir: Function;
-export declare const readdir: Function;
-export declare const stat: Function;
-export declare const readFile: Function;
-export declare const writeFile: Function;
-export declare const unlink: Function;
-export declare const realpath: Function;
+export = _exports;

--- a/typings/runtime.config.d.ts
+++ b/typings/runtime.config.d.ts
@@ -1,12 +1,12 @@
 declare namespace _default {
-    namespace queryHandler {
-        function parse(search: any): any;
-        function stringify(params: any): string;
+    export namespace queryHandler {
+        export function parse(search: any): any;
+        export function stringify(params: any): string;
     }
-    namespace urlTransform {
-        function apply(x: any): any;
-        function remove(x: any): any;
+    export namespace urlTransform {
+        export function apply(x: any): any;
+        export function remove(x: any): any;
     }
-    const useHash: boolean;
+    export const useHash: boolean;
 }
 export default _default;

--- a/typings/runtime/defaultTmp/routes.d.ts
+++ b/typings/runtime/defaultTmp/routes.d.ts
@@ -7,10 +7,10 @@ export const __version: "0.0.0-development";
 export const __timestamp: "2020-04-14T07:23:45.459Z";
 export const options: {};
 export namespace _tree {
-    const name: string;
-    const filepath: string;
-    const root: boolean;
-    const children: {
+    export const name: string;
+    export const filepath: string;
+    export const root: boolean;
+    export const children: {
         isFile: boolean;
         isDir: boolean;
         ext: string;
@@ -29,17 +29,17 @@ export namespace _tree {
         id: string;
         component: () => typeof Splash;
     }[];
-    const isLayout: boolean;
-    const isReset: boolean;
-    const isIndex: boolean;
-    const isFallback: boolean;
-    const meta: {
+    export const isLayout: boolean;
+    export const isReset: boolean;
+    export const isIndex: boolean;
+    export const isFallback: boolean;
+    export const meta: {
         preload: boolean;
         "precache-order": boolean;
         "precache-proximity": boolean;
         recursive: boolean;
     };
-    const path: string;
+    export const path: string;
 }
 export const tree: any;
 export const routes: any[];

--- a/typings/runtime/helpers.d.ts
+++ b/typings/runtime/helpers.d.ts
@@ -28,7 +28,7 @@ export function prefetch(path: string | ClientNodeApi, options: any): void;
  * @typedef {function(ClientNodeApi, ClientNodeApi):ConcestorReturn} GetConcestor
  * @type {GetConcestor}
  */
-export function getConcestor(nodeApi1: ClientNodeApi, nodeApi2: ClientNodeApi): ConcestorReturn;
+export function getConcestor(nodeApi1: ClientNodeApi, nodeApi2: ClientNodeApi): [ClientNodeApi, ClientNodeApi, ClientNodeApi];
 /**
  * Get index difference between two paths
  *
@@ -45,10 +45,11 @@ export function getDirection(paths: any[], newPath: object, oldPath: object): nu
  * @type {FocusHelper}
  */
 export function focus(element: HTMLElement): void;
-export namespace components {
-    function subscribe(run: any): () => void;
-    function subscribe(run: any): () => void;
+export namespace nodes {
+    export function subscribe(run: any): import("svelte/store").Unsubscriber;
+    export function subscribe(run: any): import("svelte/store").Unsubscriber;
 }
+export namespace components { }
 /**
  * @typedef {import('svelte/store').Readable<ClientNodeApi>} ClientNodeHelperStore
  * @type { ClientNodeHelperStore }
@@ -63,13 +64,15 @@ export const layout: import("svelte/store").Readable<ClientNodeApi>;
 * @typedef {import('svelte/store').Readable<ContextHelper>} ContextHelperStore
 * @type {ContextHelperStore}
 */
-export const context: import("svelte/store").Readable<ContextHelper>;
+export const context: import("svelte/store").Readable<{
+    component: ClientNode;
+}>;
 /**
  * @typedef {function():void} ReadyHelper
  * @typedef {import('svelte/store').Readable<ReadyHelper>} ReadyHelperStore
  * @type {ReadyHelperStore}
 */
-export const ready: import("svelte/store").Readable<ReadyHelper>;
+export const ready: import("svelte/store").Readable<() => void>;
 /**
  * @callback AfterPageLoadHelper
  * @param {function} callback
@@ -110,16 +113,19 @@ export const meta: import("svelte/store").Readable<{
     [x: string]: any;
 }>;
 /**
- * @callback UrlHelper
- * @param {String=} path
- * @param {UrlParams=} params
- * @param {UrlOptions=} options
- * @return {String}
- *
+ * @typedef {{
+ *   (el: Node): {update: (args: any) => void;}
+ *   (path?: string | undefined, params?: UrlParams | undefined, options?: UrlOptions | undefined): string;
+ * }} UrlHelper
  * @typedef {import('svelte/store').Readable<UrlHelper>} UrlHelperStore
  * @type {UrlHelperStore}
  * */
-export const url: import("svelte/store").Readable<UrlHelper>;
+export const url: import("svelte/store").Readable<{
+    (el: Node): {
+        update: (args: any) => void;
+    };
+    (path?: string | undefined, params?: UrlParams | undefined, options?: UrlOptions | undefined): string;
+}>;
 /**
 * @callback GotoHelper
 * @param {String=} path
@@ -156,7 +162,7 @@ export type RoutifyContext = {
     componentFile: any;
 };
 export type ConcestorReturn = [ClientNodeApi, ClientNodeApi, ClientNodeApi];
-export type GetConcestor = (arg0: ClientNodeApi, arg1: ClientNodeApi) => ConcestorReturn;
+export type GetConcestor = (arg0: ClientNodeApi, arg1: ClientNodeApi) => [ClientNodeApi, ClientNodeApi, ClientNodeApi];
 /**
  * Sets element to active
  */
@@ -165,9 +171,11 @@ export type ClientNodeHelperStore = import("svelte/store").Readable<ClientNodeAp
 export type ContextHelper = {
     component: ClientNode;
 };
-export type ContextHelperStore = import("svelte/store").Readable<ContextHelper>;
+export type ContextHelperStore = import("svelte/store").Readable<{
+    component: ClientNode;
+}>;
 export type ReadyHelper = () => void;
-export type ReadyHelperStore = import("svelte/store").Readable<ReadyHelper>;
+export type ReadyHelperStore = import("svelte/store").Readable<() => void>;
 export type AfterPageLoadHelper = (callback: Function) => any;
 export type AfterPageLoadHelperStore = import("svelte/store").Readable<AfterPageLoadHelper> & {
     _hooks: Array<Function>;
@@ -196,10 +204,17 @@ export type MetaHelperStore = import("svelte/store").Readable<{
     [x: string]: any;
 }>;
 export type UrlHelper = {
-    (el: Node): {update: (args: any) => void;}
+    (el: Node): {
+        update: (args: any) => void;
+    };
     (path?: string | undefined, params?: UrlParams | undefined, options?: UrlOptions | undefined): string;
 };
-export type UrlHelperStore = import("svelte/store").Readable<UrlHelper>;
+export type UrlHelperStore = import("svelte/store").Readable<{
+    (el: Node): {
+        update: (args: any) => void;
+    };
+    (path?: string | undefined, params?: UrlParams | undefined, options?: UrlOptions | undefined): string;
+}>;
 export type GotoHelper = (path?: string | undefined, params?: UrlParams | undefined, options?: GotoOptions | undefined) => any;
 export type GotoHelperStore = import("svelte/store").Readable<GotoHelper>;
 export type IsActiveHelper = (path?: string | undefined, params?: UrlParams | undefined, options?: UrlOptions | undefined) => boolean;

--- a/typings/runtime/helpers.d.ts
+++ b/typings/runtime/helpers.d.ts
@@ -195,7 +195,10 @@ export type LeftoverHelperStore = import("svelte/store").Readable<string>;
 export type MetaHelperStore = import("svelte/store").Readable<{
     [x: string]: any;
 }>;
-export type UrlHelper = (path?: string | undefined, params?: UrlParams | undefined, options?: UrlOptions | undefined) => string;
+export type UrlHelper = {
+    (el: Node): {update: (args: any) => void;}
+    (path?: string | undefined, params?: UrlParams | undefined, options?: UrlOptions | undefined): string;
+};
 export type UrlHelperStore = import("svelte/store").Readable<UrlHelper>;
 export type GotoHelper = (path?: string | undefined, params?: UrlParams | undefined, options?: GotoOptions | undefined) => any;
 export type GotoHelperStore = import("svelte/store").Readable<GotoHelper>;

--- a/typings/runtime/middleware.d.ts
+++ b/typings/runtime/middleware.d.ts
@@ -41,13 +41,13 @@ export type NodeWalkerProxy = (NodePayload: NodePayload) => any;
  * @param {NodeWalkerProxy} fn function to be called for each file
  * @param {NodePayload=} payload
  */
-export function nodeMiddleware(fn: NodeWalkerProxy, payload?: NodePayload | undefined): Promise<any>;
+export function nodeMiddleware(fn: NodeWalkerProxy, payload?: NodePayload | undefined): Promise<boolean>;
 /**
  * Node walker (sync version)
  * @param {NodeWalkerProxy} fn function to be called for each file
  * @param {NodePayload=} payload
  */
-export function nodeMiddlewareSync(fn: NodeWalkerProxy, payload?: NodePayload | undefined): any;
+export function nodeMiddlewareSync(fn: NodeWalkerProxy, payload?: NodePayload | undefined): boolean;
 /**
  * Node payload
  * @typedef {Object} NodePayload
@@ -71,10 +71,10 @@ export function nodeMiddlewareSync(fn: NodeWalkerProxy, payload?: NodePayload | 
  * @param {NodeWalkerProxy} fn
  */
 export function createNodeMiddleware(fn: NodeWalkerProxy): {
-    (payload: TreePayload): Promise<any>;
+    (payload: TreePayload): Promise<boolean>;
     /**
      * NodeMiddleware sync payload receiver
      * @param {TreePayload} payload
      */
-    sync(payload: TreePayload): any;
+    sync(payload: TreePayload): boolean;
 };

--- a/typings/runtime/plugins/assignAPI.d.ts
+++ b/typings/runtime/plugins/assignAPI.d.ts
@@ -1,4 +1,4 @@
 export const assignAPI: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };

--- a/typings/runtime/plugins/tree.d.ts
+++ b/typings/runtime/plugins/tree.d.ts
@@ -1,41 +1,41 @@
 export const setRegex: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export const setParamKeys: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export const setShortPath: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export const setRank: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export const addMetaChildren: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export const setIsIndexable: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export const assignRelations: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export const assignIndex: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export const assignLayout: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };
 export function createFlatList(treePayload: any): void;
 export const setPrototype: {
-    (payload: TreePayload): Promise<any>;
-    sync(payload: TreePayload): any;
+    (payload: TreePayload): Promise<boolean>;
+    sync(payload: TreePayload): boolean;
 };

--- a/typings/runtime/utils/index.d.ts
+++ b/typings/runtime/utils/index.d.ts
@@ -1,4 +1,4 @@
-export function handleScroll(element: any): boolean;
+export function handleScroll(element: any, scrollToTop: any): boolean;
 export function handleHash(): boolean;
 export function scrollAncestorsToTop(element: any): void;
 /** Supresses Routify caused logs and warnings for one tick */

--- a/typings/runtime/utils/normalizeNode.d.ts
+++ b/typings/runtime/utils/normalizeNode.d.ts
@@ -4,18 +4,18 @@ export function stripDefaultsAndDevProps(node: TreePayload): {
 };
 export function restoreDefaults(node: any): any;
 export namespace defaultNode {
-    const isDir: boolean;
-    const ext: string;
-    const isLayout: boolean;
-    const isReset: boolean;
-    const isIndex: boolean;
-    const isFallback: boolean;
-    const isPage: boolean;
-    const ownMeta: {};
-    namespace meta {
-        const recursive: boolean;
-        const preload: boolean;
-        const prerender: boolean;
+    export const isDir: boolean;
+    export const ext: string;
+    export const isLayout: boolean;
+    export const isReset: boolean;
+    export const isIndex: boolean;
+    export const isFallback: boolean;
+    export const isPage: boolean;
+    export const ownMeta: {};
+    export namespace meta {
+        export const recursive: boolean;
+        export const preload: boolean;
+        export const prerender: boolean;
     }
-    const id: string;
+    export const id: string;
 }

--- a/typings/runtime/utils/onPageLoaded.d.ts
+++ b/typings/runtime/utils/onPageLoaded.d.ts
@@ -1,5 +1,6 @@
-export function onPageLoaded({ page, metatags, afterPageLoad }: {
+export function onPageLoaded({ page, metatags, afterPageLoad, parentNode }: {
     page: any;
     metatags: any;
     afterPageLoad: any;
+    parentNode: any;
 }): Promise<void>;

--- a/typings/typedef.d.ts
+++ b/typings/typedef.d.ts
@@ -114,8 +114,8 @@ type BuildConfig = {
     dynamicImports?: boolean | undefined;
     singleBuild?: boolean | undefined;
     distDir?: string | undefined;
-    extensions?: (string | any[]) | undefined;
-    ignore?: (string | any[]) | undefined;
+    extensions?: (string | Array) | undefined;
+    ignore?: (string | Array) | undefined;
     noHashScroll?: boolean | undefined;
 };
 type UrlParams = {


### PR DESCRIPTION
This PR supports svelte files to use `use:$url` with typescript typing check.

`use:here` accepts `SvelteActionReturnType` that is defined in svelte/language-tools:

https://github.com/sveltejs/language-tools/blob/43b0411830080442e5d17d986ddd90c1aa8592e7/packages/svelte2tsx/svelte-shims.d.ts#L77-L77

```ts
type SvelteActionReturnType = {
	update?: (args: any) => void,
	destroy?: () => void
} | void
```

We can verify this PR in current version easily with:

```svelte
<script lang="ts">
  import { url } from "@roxi/routify";

  type MyUrlHelper = {
    (el: Node): { update: (args: any) => void };
    (
      path?: string | undefined,
      params?: UrlParams | undefined,
      options?: UrlOptions | undefined
    ): string;
  };
  const myurl: MyUrlHelper = $url as any;
</script>

<a href="/" use:myurl>hi</a>
```

---

BTW, I've tried `prettier typings/runtime/helpers.d.ts` because I found [configuration section in package.json](https://github.com/roxiness/routify/blob/f9963669570f2eb6698535a4632ea39c9b78c565/package.json#L55-L59), but there were many fixes so I left as it was.