### PR TITLE
Make SvelteKit example a bit closer to SvelteKit docs

### DIFF
--- a/examples/sveltekit/src/routes/[...index].svelte
+++ b/examples/sveltekit/src/routes/[...index].svelte
@@ -5,7 +5,7 @@
     const router = createRouter({ routes })
 
     // for SSR we need to tell Sveltekit to wait for Routify to finish loading its components
-    export const load = payload => router.url.replace(payload.page.path)
+    export const load = ({ page }) => router.url.replace(page.path)
 </script>
 
 <Router {router} />


### PR DESCRIPTION
Cool example!

It took me a minute to read this and understand `payload` because that's not a term used in any of the SvelteKit examples. I think using a destructured `{ page }` arg will align a bit more with how SvelteKit's docs are written. It's also slightly shorter