### PR TITLE
Disable SvelteKit's router in example

### DIFF
--- a/examples/sveltekit/svelte.config.js
+++ b/examples/sveltekit/svelte.config.js
@@ -5,14 +5,16 @@ const config = {
     kit: {
         // hydrate the <div id="svelte"> element in src/app.html
         target: '#svelte',
-
+        
         vite: {
             plugins: [routify()],
             resolve: {
                 dedupe: ['svelte'],
             },
         },
-    },
-}
+
+        router: false
+    }
+};
 
 export default config

--- a/examples/sveltekit/svelte.config.js
+++ b/examples/sveltekit/svelte.config.js
@@ -5,7 +5,7 @@ const config = {
     kit: {
         // hydrate the <div id="svelte"> element in src/app.html
         target: '#svelte',
-        
+
         vite: {
             plugins: [routify()],
             resolve: {


### PR DESCRIPTION
Don't need SvelteKit's router if Routify's is being used!