### PR TITLE
chore: add query params and hash to sveltekit router example

### DIFF
--- a/examples/sveltekit/src/routes/[...index].svelte
+++ b/examples/sveltekit/src/routes/[...index].svelte
@@ -6,7 +6,7 @@
 
     /* for SSR we need to tell Sveltekit to wait for
        Routify to finish loading its components */
-    export const load = ({ url }) => router.url.replace(url.pathname)
+    export const load = ({ url }) => router.url.replace(url.pathname + url.search + url.hash)
 </script>
 
 <Router {router} />


### PR DESCRIPTION
Discussed a bit already in Discord, the current SvelteKit example removes query parameters and the hash from urls when loading from SSR.

It was discussed to potentially change the logic to accept an URL as an argument rather than (only?) a string, but in the meantime, having a proper example would help poeple starting with Routify v3 in SvelteKit.