### PR TITLE
Fixed ID parsing problem with different css querySelector

### DIFF
--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -12,12 +12,8 @@ export function handleHash() {
   if (navigator.userAgent.includes('jsdom')) return false
   const { hash } = window.location
   if (hash) {
-    const validElementIdRegex = /^[A-Za-z]+[\w\-\:\.]*$/
-    const elementId = hash.substring(1)
-    if (validElementIdRegex.test(elementId)) {
-      const el = document.querySelector(`[id='${elementId}']`)
-      if (el) el.scrollIntoView()
-    }
+    const el = document.getElementById(hash.substring(1))
+    if (el) el.scrollIntoView()
   }
 }
 

--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -13,8 +13,9 @@ export function handleHash() {
   const { hash } = window.location
   if (hash) {
     const validElementIdRegex = /^[A-Za-z]+[\w\-\:\.]*$/
-    if (validElementIdRegex.test(hash.substring(1))) {
-      const el = document.querySelector(hash)
+    const elementId = hash.substring(1)
+    if (validElementIdRegex.test(elementId)) {
+      const el = document.querySelector(`[id='${elementId}']`)
       if (el) el.scrollIntoView()
     }
   }


### PR DESCRIPTION
I'm not sure if you're still supporting v2 for bug fixes, and I also haven't checked if this is a thing in v3. I'm using v2 currently on quite a large application so it would be cool to have this updated for v2 as well.

Basically what was happening was although the IDs were passing the regExp id validation `/^[A-Za-z]+[\w\-\:\.]*$/` which as far as I know properly works to validate an ID selector, what was happening was the css selector in `querySelector` was throwing errors with certain patterns even though they did validate the regexp test (for example: `T-6.I.21`). Easily corrected using a different style of css query.

Note I haven't actually tested this because to get this on my app through npm sounds like a lot of work.