### PR TITLE
Fix: suppressComponentWarnings

### DIFF
--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -64,7 +64,7 @@ export function suppressComponentWarnings(ctx, tick) {
   
   const name = ctx.componentFile.name
     .replace(/Proxy<_?(.+)>/, '$1') //nollup wraps names in Proxy<...>
-    .replace(/^Index$/, (sPath.length == 0 && process.env.NODE_ENV != 'production') ? ctx.component.parent.absolutePath.split('/').pop() : sPath.split('/').pop()) //nollup names Index.svelte index. We want a real name
+    .replace(/^Index$/, (sPath.length == 0 && process.env.NODE_ENV != 'production') ? ctx.component.importPath.split('/').slice(-2, -1)[0] : sPath.split('/').pop()) //nollup names Index.svelte index. We want a real name
     .replace(/^./, s => s.toUpperCase()) //capitalize first letter
     .replace(/\:(.+)/, 'U5B$1u5D') // :id => U5Bidu5D
 

--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -64,7 +64,7 @@ export function suppressComponentWarnings(ctx, tick) {
   
   const name = ctx.componentFile.name
     .replace(/Proxy<_?(.+)>/, '$1') //nollup wraps names in Proxy<...>
-    .replace(/^Index$/, sPath.length == 0 ? ctx.component.parent.absolutePath.split('/').pop() : sPath.split('/').pop()) //nollup names Index.svelte index. We want a real name
+    .replace(/^Index$/, (sPath.length == 0 && process.env.NODE_ENV != 'production') ? ctx.component.parent.absolutePath.split('/').pop() : sPath.split('/').pop()) //nollup names Index.svelte index. We want a real name
     .replace(/^./, s => s.toUpperCase()) //capitalize first letter
     .replace(/\:(.+)/, 'U5B$1u5D') // :id => U5Bidu5D
 
@@ -80,7 +80,7 @@ export function suppressComponentWarnings(ctx, tick) {
     }
     tick().then(() => {
       //after component has been created, we want to restore the console method (log or warn)
-      console[log] = _console[log]
+      if(process.env.NODE_ENV == 'production') console[log] = _console[log]
     })
   }
 }

--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -60,9 +60,11 @@ export function suppressComponentWarnings(ctx, tick) {
   suppressComponentWarnings._console = suppressComponentWarnings._console || { log: console.log, warn: console.warn }
   const { _console } = suppressComponentWarnings
 
+  let sPath = ctx.component.shortPath
+  
   const name = ctx.componentFile.name
     .replace(/Proxy<_?(.+)>/, '$1') //nollup wraps names in Proxy<...>
-    .replace(/^Index$/, ctx.component.shortPath.split('/').pop()) //nollup names Index.svelte index. We want a real name
+    .replace(/^Index$/, sPath.length == 0 ? ctx.component.parent.absolutePath.split('/').pop() : sPath.split('/').pop()) //nollup names Index.svelte index. We want a real name
     .replace(/^./, s => s.toUpperCase()) //capitalize first letter
     .replace(/\:(.+)/, 'U5B$1u5D') // :id => U5Bidu5D
 


### PR DESCRIPTION
[VERSION USED]
@roxi/routify - 2.18.8

[ISSUE]
When the root folder contains index.js and we render the component, ctx.component.shortPath is an empty string causing the errors to not be supressed since they don't match when reaching the "if(!ignores.includes(args[0]))" statement.

[NOTES]
Modified the "suppressComponentWarnings" function rather than finding the function  that sets the shortPath directly since I'm not sure if there might be other functions that expects shortPath to contain an empty string.