### PR TITLE
rfc: skip semantic-release workflow in forked repositories

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -20,6 +20,7 @@ jobs:
 #       run: npm run test:
      
   publish:
+    if: github.repository == 'roxiness/routify'
 
     runs-on: ubuntu-latest
   


### PR DESCRIPTION
hi,

I would like to propose to skip certain jobs in forked repositories. In this case the semantic-release workflow.
It is run on every push and fails every time, as it should, any fork lacks the proper credentials to actually cut a release.

I am not very familiar with github actions, thus the RFC. According to the specification this should avoid running the semantic-release workflow outside the parent/main project/repository, but requires a double-check in case the job is skipped in every repository.

BR,
vkunz
