### PR TITLE
fix: url helper not honoring params passed in

### DIFF
--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -145,7 +145,7 @@ export function resolveUrl(path, params, inheritedParams) {
  * @param {*} params 
  */
 export function populateUrl(path, params, inheritedParams) {
-  const allParams = Object.assign({}, inheritedParams, params)
+  const allParams = Object.assign({}, params, inheritedParams)
   const queryString = getQueryString(path, params)
 
   for (const [key, value] of Object.entries(allParams))

--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -149,7 +149,7 @@ export function populateUrl(path, params, inheritedParams) {
   const queryString = getQueryString(path, params)
 
   for (const [key, value] of Object.entries(allParams))
-    path = path.replace(`:${key}`, value)
+    path = path.replace(new RegExp(`:${key}(\/|$)`), value)
 
   return `${path}${queryString}`
 }

--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -145,7 +145,7 @@ export function resolveUrl(path, params, inheritedParams) {
  * @param {*} params 
  */
 export function populateUrl(path, params, inheritedParams) {
-  const allParams = Object.assign({}, params, inheritedParams)
+  const allParams = Object.assign({}, inheritedParams, params)
   const queryString = getQueryString(path, params)
 
   for (const [key, value] of Object.entries(allParams))


### PR DESCRIPTION
If calling `$url("/some/path/:user_id", {user_id: 123})`, but your current path was "/foo/bar?u=789", because the `populateUrl` function uses the `inheritedParams` first, the result of that `$url` call would be `/some/path/789ser_id`, because it would replace only the `:u` part from the state params, instead of using the full `:user_id` from the passed params.