### PR TITLE
Fix: populateUrl with param before a slash

### DIFF
--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -148,12 +148,8 @@ export function populateUrl(path, params, inheritedParams) {
   const allParams = Object.assign({}, inheritedParams, params)
   const queryString = getQueryString(path, params)
 
-  for (const [key, value] of Object.entries(allParams)) {
-    if (path.endsWith(`:${key}`)) {
-      path = path.replace(new RegExp(`:${key}($)`), value)
-    }
-    path = path.replace(new RegExp(`:${key}(\/)`), `${value}/`)
-  }
+  for (const [key, value] of Object.entries(allParams))
+    path = path.replace(new RegExp(`:${key}(\/|$)`), value + "$1")
 
   return `${path}${queryString}`
 }

--- a/runtime/utils/index.js
+++ b/runtime/utils/index.js
@@ -148,8 +148,12 @@ export function populateUrl(path, params, inheritedParams) {
   const allParams = Object.assign({}, inheritedParams, params)
   const queryString = getQueryString(path, params)
 
-  for (const [key, value] of Object.entries(allParams))
-    path = path.replace(new RegExp(`:${key}(\/|$)`), value)
+  for (const [key, value] of Object.entries(allParams)) {
+    if (path.endsWith(`:${key}`)) {
+      path = path.replace(new RegExp(`:${key}($)`), value)
+    }
+    path = path.replace(new RegExp(`:${key}(\/)`), `${value}/`)
+  }
 
   return `${path}${queryString}`
 }


### PR DESCRIPTION
The regex match was too greedy when the param was in the middle of the url. This deals with end-of-string params first, and then handles the pre-slash params, preserving the slash.