### PR TITLE
cleanup kitchen sink multi-slot example

### DIFF
--- a/examples/kitchensink/index.html
+++ b/examples/kitchensink/index.html
@@ -1,21 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
 
-<head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <title>Svelte app</title>
 
-    <title>Svelte app</title>
+        <link
+            href="https://cdn.jsdelivr.net/npm/beercss@3.0.8/dist/cdn/beer.min.css"
+            rel="stylesheet"
+        />
+        <script
+            type="module"
+            src="https://cdn.jsdelivr.net/npm/beercss@3.0.8/dist/cdn/beer.min.js"
+        ></script>
+        <script
+            type="module"
+            src="https://cdn.jsdelivr.net/npm/material-dynamic-colors@0.1.5/dist/cdn/material-dynamic-colors.min.js"
+        ></script>
+        
+        <script type="module" src="/src/main.js"></script>
+        <!--ssr:head-->
+    </head>
 
-    <link href="https://cdn.jsdelivr.net/npm/beercss@2.2.11/dist/cdn/beer.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/beercss@2.2.11/dist/cdn/beer.min.js" type="text/javascript"></script>
-    
-    <script type="module" src="/src/main.js"></script>
-    <!--ssr:head-->
-</head>
-
-<body>
-    <!--ssr:html-->
-</body>
-
+    <body>
+        <!--ssr:html-->
+    </body>
 </html>

--- a/examples/kitchensink/src/components/Navigation.svelte
+++ b/examples/kitchensink/src/components/Navigation.svelte
@@ -1,7 +1,10 @@
 <script>
     import { isActive, node } from '@roxi/routify'
+
+    /** @type {RNodeRuntime} pages */
     export let pages = undefined
-    $: liveUrl = index => pages?.[index]?.router?.url.external()
+
+    $: liveUrl = (/** @type {number} */ index) => pages?.[index]?.router?.url.external()
 </script>
 
 <header class="fixed responsive grey3">
@@ -10,7 +13,7 @@
             <a href="/">Kitchensink</a>
         </h5>
         <div class="max" />
-
+        
         {#each $node.pages as childNode, index}
             <a
                 class="button  {$isActive(childNode.path) ? 'border' : 'transparent'}"
@@ -19,9 +22,3 @@
         {/each}
     </nav>
 </header>
-
-<style>
-    .isActive {
-        text-decoration: underline;
-    }
-</style>

--- a/examples/kitchensink/src/routes/multi-slot/1.index.md
+++ b/examples/kitchensink/src/routes/multi-slot/1.index.md
@@ -1,1 +1,1 @@
-Index page. Is it needed?
+## Index Page

--- a/examples/kitchensink/src/routes/multi-slot/__decorators/FrontpageBlock.svelte
+++ b/examples/kitchensink/src/routes/multi-slot/__decorators/FrontpageBlock.svelte
@@ -2,14 +2,16 @@
     export let context
 </script>
 
-<div class="{context.node.id} {context.node.hasComponent}">
-    {context.node.id}
+<div>
+    routes{context.node.path}.md
     <slot />
 </div>
 
 <style>
     div {
         border: 4px solid green;
-        min-height: 540px;
+        min-height: 100vh;
+        padding-inline: 5px;
+        padding-top: 65px;
     }
 </style>

--- a/examples/kitchensink/src/routes/multi-slot/_module.svelte
+++ b/examples/kitchensink/src/routes/multi-slot/_module.svelte
@@ -1,32 +1,37 @@
 <script>
-    import { url } from '@roxi/routify'
+    import { isActive, node, activeRoute, context } from '@roxi/routify'
     import FrontpageBlock from './__decorators/FrontpageBlock.svelte'
+
     /** @type {Decorator} */
     const decorator = {
         component: FrontpageBlock,
         recursive: false,
-        // shouldRender: ({ context }) => context.node.hasComponent,
     }
 </script>
 
-<nav>
-    <a href={$url('./')}>Home</a>
-    <a href={$url('./hero')}>Hero</a>
-    <a href={$url('./features')}>Features</a>
-    <a href={$url('./examples')}>Examples</a>
-</nav>
+<!-- routify:meta reset=true -->
+<header class="fixed grey3">
+    <nav>
+        <h5>
+            <a href="/">Kitchensink</a>
+        </h5>
+        <div class="max" />
+        <a
+            class="button  {$activeRoute.url === $node.path ? 'border' : 'transparent'}"
+            href={$node.path}>{$node.name}</a>
 
-<div>
+        {#each $node.pages as childNode}
+            <a
+                class="button  {$isActive(childNode.path) ? 'border' : 'transparent'}"
+                href={childNode.path}>{childNode.meta.title || childNode.name}</a>
+        {/each}
+    </nav>
+</header>
+<div class="responsive">
     <slot anchor="firstChild" multi scrollBoundary={null} {decorator} />
 </div>
 
-<!-- routify:meta reset=true -->
 <style>
-    nav {
-        position: fixed;
-        background: white;
-        z-index: 1;
-    }
     :global(*) {
         scroll-behavior: smooth;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
             },
             "peerDependencies": {
                 "spank": "^2.0.0-13",
-                "vite": "^3.2.4"
+                "vite": "^3.2.4 || ^4.0.0"
             },
             "peerDependenciesMeta": {
                 "spank": {


### PR DESCRIPTION
This PR cleans up the kitchen-sink multi-slot example.

- Interface UI to match rest of the kitchen-sink example.
- Make pages dynamic.
- Upgrade beercss to v3, this doesn't break existing styles.

![image](https://user-images.githubusercontent.com/20427502/218324591-4e6f1012-8ae8-4d7f-a1d3-a6ed0b70cb92.png)
