### PR TITLE
make `$goto()` returns empty string

### DIFF
--- a/lib/runtime/helpers/index.js
+++ b/lib/runtime/helpers/index.js
@@ -44,6 +44,7 @@ export const goto = {
             options = { ...defaults, ...options }
             const newUrl = $url(path, userParams, options)
             router.url[options.mode](newUrl, options.state)
+            return ''
         }).subscribe(run, invalidate)
     },
 }


### PR DESCRIPTION
Sometime `$goto` used in markup. this will leading to unexpected `undefined` to be printed to browser

Here the example in my use case `_reset.svelte`
```svelte
{#if $session === undefined}
    <slot />
{#else}
    {#await getSession()}
        <h1 style="margin-top:50vh; text-align:center">Loading App...</h1>
    {#then sess}
        {#if sess.status === 401}
            <slot />
        {#else}
            { $goto($redirectData.prevUrl ||'/') }
        {#endif}
    {#endawait}
{#endif}
```