### PR TITLE
Add test for resolve sibling's child

### DIFF
--- a/lib/runtime/helpers/spec/helpers.spec.js
+++ b/lib/runtime/helpers/spec/helpers.spec.js
@@ -50,7 +50,7 @@ test('can resolve named', () => {
 
 test('can resolve sibling\'s child', () => {
     const res = traverseNode(adminNode, 'posts/[slug]', mockRouter)
-    const res1 = traverseNode(crudNode, '../posts/[slug]', mockRouter)
+    const res1 = traverseNode(adminNode, '../posts/[slug]', mockRouter)
     expect(res.name).toBe('[slug]')
     expect(res1.name).toBe('[slug]')
 })

--- a/lib/runtime/helpers/spec/helpers.spec.js
+++ b/lib/runtime/helpers/spec/helpers.spec.js
@@ -48,6 +48,13 @@ test('can resolve named', () => {
     expect(res.name).toBe('admin')
 })
 
+test('can resolve sibling\'s child', () => {
+    const res = traverseNode(adminNode, 'posts/[slug]', mockRouter)
+    const res1 = traverseNode(crudNode, '../posts/[slug]', mockRouter)
+    expect(res.name).toBe('[slug]')
+    expect(res1.name).toBe('[slug]')
+})
+
 test('can find mrca', () => {
     const mrcaNode = getMRCA(slugNode, crudNode)
     expect(mrcaNode).toBe(moduleNode)


### PR DESCRIPTION
https://github.com/roxiness/routify/blob/507fe597fbcaffae5c3d56ae7f194ac90566b9c7/lib/runtime/helpers/spec/helpers.spec.js#L7-L16
```js
    const res = traverseNode(adminNode, 'posts/[slug]', mockRouter)
    expect(res.name).toBe('[slug]')
```
In this test, currently `res.name` is undefined. 
Is this normal behavior for resolving sibling's child by relative path?