### PR TITLE
fix: Use `routifyDir` and `build.outDir` paths

### DIFF
--- a/lib/extra/vite-plugin/typedef.js
+++ b/lib/extra/vite-plugin/typedef.js
@@ -17,6 +17,7 @@
  * @prop {Boolean} run Run Routify
  * @prop {Boolean} forceLogging Force logging in production
  * @prop {VitePluginSpecificOptionsRender} render
+ * @prop {string} outDir
  */
 
 /**

--- a/lib/extra/vite-plugin/utils.js
+++ b/lib/extra/vite-plugin/utils.js
@@ -54,11 +54,11 @@ export const optionsCheck = (options, isProduction) => {
  */
 export const postSsrBuildProcess = async options => {
     const type = options.render.ssr.type
-    fse.copySync(__dirname + `/assets/${type}Renderer.js`, 'dist/server/serve.js')
+    fse.copySync(__dirname + `/assets/${type}Renderer.js`, `${options.outDir}/server/serve.js`)
 
-    if (type === 'cjs') fse.writeFileSync('dist/server/package.json', '{}')
+    if (type === 'cjs') fse.writeFileSync(`${options.outDir}/server/package.json`, '{}')
 
-    fse.moveSync('dist/client/index.html', 'dist/server/index.html', { overwrite: true })
+    fse.moveSync(`${options.outDir}/client/index.html`, `${options.outDir}/server/index.html`, { overwrite: true })
 
     if (options.render.ssg.enable) {
         const spank = await getSpank()
@@ -66,7 +66,7 @@ export const postSsrBuildProcess = async options => {
     }
 
     if (!options.render.ssr.enable) {
-        fse.removeSync('dist/server')
+        fse.removeSync(`${options.outDir}/server`)
     }
 }
 

--- a/lib/extra/vite-plugin/vite-plugin.js
+++ b/lib/extra/vite-plugin/vite-plugin.js
@@ -40,20 +40,22 @@ export default function RoutifyPlugin(input = {}) {
                 // cfg.ssr.noExternal = true
                 cfg.ssr.target = 'webworker'
             }
+
+            options.routifyDir ||= './.routify'
+            options.outDir = cfg.build?.outDir || 'dist'
+
             return {
                 appType:
                     cfg.appType || (options.render.ssr.enable ? 'custom' : undefined),
                 server: {
                     fs: {
                         strict: false,
-                        allow: ['./.routify'],
+                        allow: [options.routifyDir],
                     },
                 },
                 build: {
-                    ssr: cfg.build?.ssr === true ? '.routify/render.js' : cfg.build?.ssr,
-                    outDir:
-                        cfg.build?.outDir ||
-                        (cfg.build?.ssr ? 'dist/server' : 'dist/client'),
+                    ssr: cfg.build?.ssr === true ? `${options.routifyDir}/render.js` : cfg.build?.ssr,
+                    outDir: `${options.outDir}/${cfg.build?.ssr ? 'server' : 'client'}`,
                 },
                 envPrefix: ['VITE_', 'ROUTIFY_SSR_ENABLE'],
             }
@@ -73,7 +75,7 @@ export default function RoutifyPlugin(input = {}) {
         closeBundle: async () => {
             if (options.render.ssg.enable || options.render.ssr.enable) {
                 // build again, this time in the dist/server dir
-                if (!isSsr) await build({ build: { ssr: true } })
+                if (!isSsr) await build({ build: { ssr: true, outDir: options.outDir } })
                 else await postSsrBuildProcess(options)
             }
         },

--- a/typings/lib/extra/vite-plugin/typedef.d.ts
+++ b/typings/lib/extra/vite-plugin/typedef.d.ts
@@ -36,6 +36,7 @@ type VitePluginSpecificOptions = {
      */
     forceLogging: boolean;
     render: VitePluginSpecificOptionsRender;
+    outDir: string;
 };
 type VitePluginSpecificOptionsInput = {
     /**


### PR DESCRIPTION
This allows to use custom paths defined by  `routifyDir` and/or `build.outDir`