### PR TITLE
fix: v2 remove unmaintained esm dependency to fix Node22 compatibility

### DIFF
--- a/lib/middleware/createTemplate.js
+++ b/lib/middleware/createTemplate.js
@@ -1,4 +1,4 @@
-const { stripDefaultsAndDevProps } = require("esm")(module)('../../runtime/utils/normalizeNode')
+const { stripDefaultsAndDevProps } = require('../utils/normalizeNode')
 
 const { name, version } = require('../../package.json')
 

--- a/lib/utils/middleware.js
+++ b/lib/utils/middleware.js
@@ -1,2 +1,108 @@
-require = require("esm")(module/*, options*/)
-module.exports = require("../../runtime/middleware")
+/**
+ * CommonJS implementation of the node middleware helpers.
+ *
+ * This used to proxy the ESM implementation in `runtime/middleware.js` via the
+ * unmaintained `esm` package. Keeping a CJS copy here avoids loaders and works
+ * on Node 22+, while still supporting older Node versions.
+ */
+
+/**
+ * Node middleware
+ * @description Walks through the nodes of a tree
+ * @example middleware = createNodeMiddleware(payload => {payload.file.name = 'hello'})(treePayload))
+ * @param {(payload: any) => any} fn
+ */
+function createNodeMiddleware(fn) {
+	/**
+	 * NodeMiddleware payload receiver
+	 * @param {TreePayload} payload
+	 */
+	const inner = async function execute(payload) {
+		return await nodeMiddleware(fn, {
+			file: payload.tree,
+			state: { treePayload: payload },
+			scope: {},
+		})
+	}
+
+	/**
+	 * NodeMiddleware sync payload receiver
+	 * @param {TreePayload} payload
+	 */
+	inner.sync = function executeSync(payload) {
+		return nodeMiddlewareSync(fn, {
+			file: payload.tree,
+			state: { treePayload: payload },
+			scope: {},
+		})
+	}
+
+	return inner
+}
+
+/**
+ * Node walker
+ * @param {(payload: any) => any} fn function to be called for each file
+ * @param {any=} payload
+ */
+async function nodeMiddleware(fn, payload) {
+	const _file = await fn(payload)
+	if (_file === false) return false
+	const file = _file || payload.file
+
+	if (file.children) {
+		const children = await Promise.all(
+			file.children.map(async _child =>
+				nodeMiddleware(fn, {
+					state: payload.state,
+					scope: clone(payload.scope || {}),
+					parent: payload.file,
+					file: await _child,
+				})
+			)
+		)
+		file.children = children.filter(Boolean)
+	}
+
+	return file
+}
+
+/**
+ * Node walker (sync version)
+ * @param {(payload: any) => any} fn function to be called for each file
+ * @param {any=} payload
+ */
+function nodeMiddlewareSync(fn, payload) {
+	const _file = fn(payload)
+	if (_file === false) return false
+
+	const file = _file || payload.file
+
+	if (file.children) {
+		const children = file.children.map(_child =>
+			nodeMiddlewareSync(fn, {
+				state: payload.state,
+				scope: clone(payload.scope || {}),
+				parent: payload.file,
+				file: _child,
+			})
+		)
+		file.children = children.filter(Boolean)
+	}
+
+	return file
+}
+
+/**
+ * Clone with JSON
+ * @param {any} obj
+ */
+function clone(obj) {
+	return JSON.parse(JSON.stringify(obj))
+}
+
+module.exports = {
+	nodeMiddleware,
+	nodeMiddlewareSync,
+	createNodeMiddleware,
+}

--- a/lib/utils/normalizeNode.js
+++ b/lib/utils/normalizeNode.js
@@ -1,0 +1,61 @@
+const defaultNode = {
+    isDir: false,
+    ext: 'svelte',
+    isLayout: false,
+    isReset: false,
+    isIndex: false,
+    isFallback: false,
+    isPage: false,
+    ownMeta: {},
+    meta: {
+        recursive: true,
+        preload: false,
+        prerender: true,
+    },
+    id: '__fallback',
+}
+
+const devProps = [
+    'file',
+    'filepath',
+    'name',
+    'badExt',
+    'relativeDir',
+    'absolutePath',
+    'importPath',
+    'isFile',
+]
+
+/** @param {TreePayload} node */
+function stripDefaultsAndDevProps(node) {
+    const strippedNode = {}
+
+    Object.entries(node)
+        .filter(([key]) => !devProps.includes(key))
+        .filter(
+            ([key, value]) =>
+                JSON.stringify(defaultNode[key]) !== JSON.stringify(value)
+        )
+        .forEach(([key, value]) => (strippedNode[key] = value))
+
+    if (node.children)
+        strippedNode.children = [...node.children.map(stripDefaultsAndDevProps)]
+
+    return strippedNode
+}
+
+function restoreDefaults(node) {
+    Object.entries(defaultNode).forEach(([key, value]) => {
+        if (typeof node[key] === 'undefined') node[key] = value
+    })
+
+    if (node.children) node.children = node.children.map(restoreDefaults)
+
+    return node
+}
+
+module.exports = {
+    defaultNode,
+    stripDefaultsAndDevProps,
+    restoreDefaults,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "cheap-watch": "^1.0.4",
         "commander": "^7.2.0",
         "configent": "^2.2.0",
-        "esm": "^3.2.25",
         "fs-extra": "^9.1.0",
         "log-symbols": "^3.0.0",
         "picomatch": "^2.3.1",
@@ -1543,6 +1542,7 @@
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9255,7 +9255,8 @@
     "esm": {
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -323,7 +323,6 @@
         "cheap-watch": "^1.0.2",
         "commander": "^7.1.0",
         "configent": "^2.1.4",
-        "esm": "^3.2.25",
         "fs-extra": "^9.0.1",
         "log-symbols": "^3.0.0",
         "picomatch": "^2.2.2",
@@ -1536,15 +1535,6 @@
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/esprima": {
@@ -8307,7 +8297,6 @@
         "cheap-watch": "^1.0.2",
         "commander": "^7.1.0",
         "configent": "^2.1.4",
-        "esm": "^3.2.25",
         "fs-extra": "^9.0.1",
         "log-symbols": "^3.0.0",
         "picomatch": "^2.2.2",
@@ -9251,12 +9240,6 @@
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
       }
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true
     },
     "esprima": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "./plugins/*": "./plugins/*",
     "./hmr": "./hmr.js",
     "./lib/utils/config": "./lib/utils/config.js"
-
   },
   "dependencies": {
     "@roxi/ssr": "^0.2.1",
@@ -42,7 +41,6 @@
     "cheap-watch": "^1.0.4",
     "commander": "^7.2.0",
     "configent": "^2.2.0",
-    "esm": "^3.2.25",
     "fs-extra": "^9.1.0",
     "log-symbols": "^3.0.0",
     "picomatch": "^2.3.1",

--- a/typings/lib/utils/middleware.d.ts
+++ b/typings/lib/utils/middleware.d.ts
@@ -1,2 +1,2 @@
-declare const _exports: typeof import("../middleware");
+declare const _exports: typeof import("../../runtime/middleware");
 export = _exports;


### PR DESCRIPTION
## [v2] remove unmaintained esm dependency to fix Node22 compatibility

### Summary
This PR removes the unmaintained `esm` dependency from Routify v2’s Node-side CLI/build pipeline (`routify -b`) and replaces the two `esm`-based shims with small native CommonJS implementations.

### Background / Problem
After upgrading to Node.js 22, running `routify -b` crashes because the `esm` package no longer works correctly on Node 22.

```console
TypeError: Function.prototype.apply was called on undefined, which is a undefined and not a function
    at Object.<anonymous> (.../lib/utils/middleware.js:2:18)
```

Root cause: `lib/` is CommonJS and was using `require("esm")(module)(...)` to synchronously load ESM modules from `runtime/`. This loader is unmaintained and breaks on Node 22.

### What changed
- Replaced the `esm` proxy in `lib/utils/middleware.js` with a native CommonJS implementation of:
  - `createNodeMiddleware`
  - `nodeMiddleware`
  - `nodeMiddlewareSync`
- Added a small CommonJS helper `lib/utils/normalizeNode.js` exporting:
  - `defaultNode`
  - `stripDefaultsAndDevProps`
  - `restoreDefaults`
- Updated `lib/middleware/createTemplate.js` to import `stripDefaultsAndDevProps` from `lib/utils/normalizeNode.js` instead of loading `runtime/utils/normalizeNode.js` through `esm`.
- Removed `esm` from `dependencies`.

### Why this approach
- No new dependencies (avoids swapping `esm` for another loader/transpiler).
- Keeps the `runtime/` ESM modules unchanged (so bundler/browser behavior is unaffected).
- Avoids async refactors in the CLI pipeline (a true `esm` “replacement” would generally require `await import(...)`).
- Works on Node 22 while remaining compatible with older Node versions.

### Downside

Yes, it duplicates a small amount of code—but only for the Node CLI/build path, and it’s stable logic that rarely changes.
